### PR TITLE
fix: archive oci-melb-1 storage reshape

### DIFF
--- a/hosts/oci-melb-1/default.nix
+++ b/hosts/oci-melb-1/default.nix
@@ -21,7 +21,7 @@ in
     ../../modules/applications/music.nix
     ../../modules/applications/edge-ingress.nix
     ../../modules/providers/oci/default.nix
-    ../../modules/storage/disko-root.nix
+    ../../modules/storage/disko-single-disk-split.nix
     ../../modules/core/users.nix
     ../../modules/services/admin/cockpit.nix
     ../../modules/services/bifrost-gateway.nix
@@ -42,7 +42,6 @@ in
   ];
 
   disko.devices.disk.main.device = "/dev/sda";
-  disko.devices.disk.media.device = "/dev/sdb";
   applications.music.enable = true;
   applications.music.dataRoot = "/srv/data";
   applications.music.mediaRoot = "/srv/media";
@@ -123,8 +122,10 @@ in
     secretFiles.oidc = ../../secrets/hosts/oci-melb-1/oidc.yaml;
   };
 
-  # Configurable root size — set here so it's visible in one place per host.
+  # Match the current OCI boot-volume partition layout.
   disko-root-extra = "20G";
+  disko-data-size = "28G";
+  disko-nix-size = "45G";
 
   environment.systemPackages = with pkgs; [
     git
@@ -154,8 +155,15 @@ in
     }
   );
 
-  services.tailscale = lib.mkIf hasHostSecrets {
-    authKeyFile = "/run/secrets/tailscale.auth_key";
+  services.tailscale = lib.mkIf hasHostSecrets { authKeyFile = "/run/secrets/tailscale.auth_key"; };
+
+  services.hostRecovery = lib.mkIf hasHostSecrets {
+    enable = true;
+    secretFile = ../../secrets/hosts/oci-melb-1/system.yaml;
+    rescueUser = {
+      name = "rescue";
+    };
+    reboot.onCalendar = "weekly";
   };
 
   services.beszel-agent-auth = {
@@ -167,7 +175,10 @@ in
     enable = true;
     secretFile = ../../secrets/hosts/oci-melb-1/system.yaml;
     bucket = "shrublab-backup-oci-melb-1";
+    stagingRoot = "/srv/data/state-backups";
   };
+
+  services.tagr.backup.exportFile = "/srv/data/state-backups/tagr/tagr.sqlite3";
 
   programs.nix-ld = {
     enable = true;

--- a/modules/applications/music.nix
+++ b/modules/applications/music.nix
@@ -174,7 +174,13 @@ in
       dataDir = "${cfg.dataRoot}/syncthing";
       configDir = "${cfg.dataRoot}/syncthing/config";
       deviceTargets = cfg.syncthingDevices;
-      folderTargets = cfg.syncthingFolders;
+      folderTargets = lib.mapAttrs (
+        _name: folder:
+        folder
+        // {
+          ensureDir = false;
+        }
+      ) cfg.syncthingFolders;
     };
 
     services.state-backups.services.syncthing = {
@@ -282,6 +288,7 @@ in
       description = "Reconcile media directory ACLs and POSIX permissions recursively";
       after = [ "systemd-tmpfiles-setup.service" ];
       unitConfig.RequiresMountsFor = [ cfg.mediaRoot ];
+      wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         Type = "oneshot";
         ExecStart = "${mediaPermissionReconcile}/bin/media-permission-reconcile";

--- a/modules/services/beets-inbox.nix
+++ b/modules/services/beets-inbox.nix
@@ -2,19 +2,21 @@
   config,
   lib,
   pkgs,
-  inputs,
   ...
 }:
 let
   cfg = config.services.beets-inbox;
   secretHelpers = import ../../lib/secrets.nix { inherit lib; };
 
-  mediaInboxDir = if cfg.inboxDir != null then cfg.inboxDir else "${cfg.mediaRoot}/inbox";
-  mediaLibraryDir = if cfg.libraryDir != null then cfg.libraryDir else "${cfg.mediaRoot}/library";
-  mediaQuarantineDir =
-    if cfg.quarantineDir != null then cfg.quarantineDir else "${cfg.mediaRoot}/quarantine";
-  mediaUntaggedDir = "${mediaQuarantineDir}/untagged";
-  mediaApprovedDir = "${mediaQuarantineDir}/approved";
+  mediaPaths = rec {
+    inboxDir = if cfg.inboxDir != null then cfg.inboxDir else "${cfg.mediaRoot}/inbox";
+    libraryDir = if cfg.libraryDir != null then cfg.libraryDir else "${cfg.mediaRoot}/library";
+    quarantineDir =
+      if cfg.quarantineDir != null then cfg.quarantineDir else "${cfg.mediaRoot}/quarantine";
+    untaggedDir = "${quarantineDir}/untagged";
+    approvedDir = "${quarantineDir}/approved";
+    writableMediaDirs = [ libraryDir quarantineDir untaggedDir approvedDir ];
+  };
 
   beetsRuntime = pkgs.python3Packages.beets.override {
     pluginOverrides = {
@@ -25,107 +27,217 @@ let
     };
   };
 
-  beetsConfig = pkgs.writeText "beets-config.yaml" (
-    builtins.readFile ../../scripts/beets-config.yaml
-  );
+  beetsConfigNames = [
+    "beets-config.yaml"
+    "beets-approved-config.yaml"
+    "beets-quarantine-config.yaml"
+  ];
 
-  beetsApprovedConfig = pkgs.writeText "beets-approved-config.yaml" (
-    builtins.readFile ../../scripts/beets-approved-config.yaml
-  );
+  mkBeetsConfig = name:
+    pkgs.writeText name (builtins.readFile ../../scripts/${name});
 
-  beetsConfigSource =
-    if lib.hasAttrByPath [ "sops" "templates" "beets-config.yaml" "path" ] config then
-      config.sops.templates."beets-config.yaml".path
+  mkBeetsConfigSource = name:
+    if lib.hasAttrByPath [ "sops" "templates" name "path" ] config then
+      config.sops.templates.${name}.path
     else
-      beetsConfig;
+      mkBeetsConfig name;
 
-  beetsApprovedConfigSource =
-    if lib.hasAttrByPath [ "sops" "templates" "beets-approved-config.yaml" "path" ] config then
-      config.sops.templates."beets-approved-config.yaml".path
-    else
-      beetsApprovedConfig;
+  beetsSecretEntries = [
+    {
+      secretName = "beets_discogs_token";
+      key = "beets/discogs_token";
+      placeholder = "REPLACE_WITH_DISCOGS_USER_TOKEN";
+    }
+    {
+      secretName = "beets_spotify_client_id";
+      key = "beets/spotify_client_id";
+      placeholder = "REPLACE_WITH_SPOTIFY_CLIENT_ID";
+    }
+    {
+      secretName = "beets_spotify_client_secret";
+      key = "beets/spotify_client_secret";
+      placeholder = "REPLACE_WITH_SPOTIFY_CLIENT_SECRET";
+    }
+  ];
 
-  beetsInboxRunner = pkgs.writeShellApplication {
-    name = "beets-inbox-runner";
-    runtimeInputs = [
-      beetsRuntime
-      pkgs.coreutils
-      pkgs.findutils
-      pkgs.gnused
-    ];
-    text = ''
-      BEETS_CONFIG_SOURCE=${beetsConfigSource}
-      BEETS_APPROVED_CONFIG_SOURCE=${beetsApprovedConfigSource}
-      ${builtins.readFile ../../scripts/beets-inbox-runner.sh}
-    '';
+  mkSopsTemplate = name: {
+    owner = "beets";
+    group = "beets";
+    mode = "0440";
+    content =
+      builtins.replaceStrings
+        (map (e: e.placeholder) beetsSecretEntries)
+        (map (e: config.sops.placeholder.${e.secretName}) beetsSecretEntries)
+        (builtins.readFile ../../scripts/${name});
   };
 
-  beetsQuarantineApprovedRunner = pkgs.writeShellApplication {
-    name = "beets-quarantine-approved-runner";
-    runtimeInputs = [
-      beetsRuntime
-      pkgs.coreutils
-      pkgs.findutils
-      pkgs.gnused
-    ];
-    text = ''
-      BEETS_CONFIG_SOURCE=${beetsConfigSource}
-      ${builtins.readFile ../../scripts/beets-inbox-runner.sh}
-    '';
+  mkSopsSecret = { secretName, key, ... }: {
+    sopsFile = cfg.secretFiles.host;
+    inherit key;
+    path = "/run/secrets/beets.${builtins.replaceStrings [ "beets_" ] [ "" ] secretName}";
+    owner = "beets";
+    group = "beets";
   };
 
-  beetsPermissionReconcile = pkgs.writeShellApplication {
-    name = "beets-permission-reconcile";
-    runtimeInputs = [
-      pkgs.coreutils
-      pkgs.findutils
-      pkgs.acl
-    ];
-    text = ''
-      set -euo pipefail
+  beetsRunners = rec {
+    inbox = pkgs.writeShellApplication {
+      name = "beets-inbox-runner";
+      runtimeInputs = [ beetsRuntime pkgs.coreutils pkgs.findutils pkgs.gnused ];
+      text = ''
+        BEETS_CONFIG_SOURCE=${mkBeetsConfigSource "beets-config.yaml"}
+        BEETS_APPROVED_CONFIG_SOURCE=${mkBeetsConfigSource "beets-approved-config.yaml"}
+        ${builtins.readFile ../../scripts/beets-inbox-runner.sh}
+      '';
+    };
 
-      LIBRARY_ROOT=${mediaLibraryDir}
-      QUARANTINE_ROOT=${mediaQuarantineDir}
-      UNTAGGED_ROOT=${mediaUntaggedDir}
-      APPROVED_ROOT=${mediaApprovedDir}
+    quarantineApproved = pkgs.writeShellApplication {
+      name = "beets-quarantine-approved-runner";
+      runtimeInputs = [ beetsRuntime pkgs.coreutils pkgs.findutils pkgs.gnused ];
+      text = ''
+        BEETS_CONFIG_SOURCE=${mkBeetsConfigSource "beets-config.yaml"}
+        ${builtins.readFile ../../scripts/beets-inbox-runner.sh}
+      '';
+    };
 
-      if [[ -d "$LIBRARY_ROOT" ]]; then
-        find "$LIBRARY_ROOT" -type d -exec chgrp music-ingest {} +
-        find "$LIBRARY_ROOT" -type d -exec chmod 2775 {} +
-        find "$LIBRARY_ROOT" -type f -exec chgrp music-ingest {} +
-        find "$LIBRARY_ROOT" -type f -exec chmod 0664 {} +
-        setfacl -R -m g:music-ingest:rwx "$LIBRARY_ROOT"
-        find "$LIBRARY_ROOT" -type d -exec setfacl -m d:g:music-ingest:rwX {} +
-        setfacl -R -m g:media:r-X "$LIBRARY_ROOT"
-        find "$LIBRARY_ROOT" -type d -exec setfacl -m d:g:media:r-X {} +
-      fi
+    quarantine = pkgs.writeShellApplication {
+      name = "beets-quarantine-runner";
+      runtimeInputs = [ beetsRuntime pkgs.coreutils ];
+      text = ''
+        set -euo pipefail
+        BEETS_DATA_DIR="${cfg.dataDir}"
+        export BEETSDIR="$BEETS_DATA_DIR"
+        export HOME="$BEETS_DATA_DIR"
+        mkdir -p "$BEETS_DATA_DIR/state"
+        TARGET="''${1:-${mediaPaths.untaggedDir}}"
+        exec beet -c "${mkBeetsConfigSource "beets-quarantine-config.yaml"}" import "$TARGET"
+      '';
+    };
 
-      if [[ -d "$QUARANTINE_ROOT" ]]; then
-        find "$QUARANTINE_ROOT" -type d -exec chgrp music-ingest {} +
-        find "$QUARANTINE_ROOT" -type d -exec chmod 2775 {} +
-        find "$QUARANTINE_ROOT" -type f -exec chgrp music-ingest {} +
-        find "$QUARANTINE_ROOT" -type f -exec chmod 0664 {} +
-        setfacl -R -m g:music-ingest:rwx "$QUARANTINE_ROOT"
-        find "$QUARANTINE_ROOT" -type d -exec setfacl -m d:g:music-ingest:rwX {} +
-        setfacl -R -m g:media:r-X "$QUARANTINE_ROOT"
-        find "$QUARANTINE_ROOT" -type d -exec setfacl -m d:g:media:r-X {} +
-      fi
+    interactive = pkgs.writeShellApplication {
+      name = "beets-interactive";
+      runtimeInputs = [ pkgs.coreutils ];
+      text = ''
+        set -euo pipefail
+        TARGET="''${1:-${mediaPaths.untaggedDir}}"
+        exec sudo -u beets -H "${quarantine}/bin/beets-quarantine-runner" "$TARGET"
+      '';
+    };
 
-      if [[ -d "$UNTAGGED_ROOT" ]]; then
-        setfacl -R -m g:music-ingest:rwx "$UNTAGGED_ROOT"
-        find "$UNTAGGED_ROOT" -type d -exec setfacl -m d:g:music-ingest:rwX {} +
-        setfacl -R -m g:media:r-X "$UNTAGGED_ROOT"
-        find "$UNTAGGED_ROOT" -type d -exec setfacl -m d:g:media:r-X {} +
-      fi
+    convert = pkgs.writeShellApplication {
+      name = "beets-convert-runner";
+      runtimeInputs = [ beetsRuntime pkgs.coreutils pkgs.ffmpeg ];
+      text = ''
+        set -euo pipefail
+        BEETS_DATA_DIR="${cfg.dataDir}"
+        export BEETSDIR="$BEETS_DATA_DIR"
+        export HOME="$BEETS_DATA_DIR"
+        mkdir -p "$BEETS_DATA_DIR/state"
+        QUERY="''${1:-}"
+        exec beet -c "${mkBeetsConfigSource "beets-config.yaml"}" convert ''${QUERY:+"$QUERY"}
+      '';
+    };
 
-      if [[ -d "$APPROVED_ROOT" ]]; then
-        setfacl -R -m g:music-ingest:rwx "$APPROVED_ROOT"
-        find "$APPROVED_ROOT" -type d -exec setfacl -m d:g:music-ingest:rwX {} +
-        setfacl -R -m g:media:r-X "$APPROVED_ROOT"
-        find "$APPROVED_ROOT" -type d -exec setfacl -m d:g:media:r-X {} +
-      fi
-    '';
+    reconcile = pkgs.writeShellApplication {
+      name = "beets-reconcile-runner";
+      runtimeInputs = [ beetsRuntime pkgs.coreutils pkgs.ffmpeg ];
+      text = ''
+        set -euo pipefail
+        BEETS_DATA_DIR="${cfg.dataDir}"
+        export BEETSDIR="$BEETS_DATA_DIR"
+        export HOME="$BEETS_DATA_DIR"
+        mkdir -p "$BEETS_DATA_DIR/state"
+        CONFIG="${mkBeetsConfigSource "beets-config.yaml"}"
+        echo "=== beet update (re-read tags from files) ==="
+        beet -c "$CONFIG" update -a
+        echo "=== beet check (verify library integrity) ==="
+        beet -c "$CONFIG" check
+        echo "=== beet convert (lossless -> AIFF where not yet converted) ==="
+        beet -c "$CONFIG" convert
+        echo "=== beet duplicates (detect duplicate albums) ==="
+        beet -c "$CONFIG" duplicates -a
+        echo "=== beet move (reorganize files to match path templates) ==="
+        beet -c "$CONFIG" move
+      '';
+    };
+
+    permissionReconcile = pkgs.writeShellApplication {
+      name = "beets-permission-reconcile";
+      runtimeInputs = [ pkgs.coreutils pkgs.findutils pkgs.acl ];
+      text = ''
+        set -euo pipefail
+        fixup() {
+          local dir="$1"
+          [[ -d "$dir" ]] || return 0
+          find "$dir" -type d -exec chgrp music-ingest {} +
+          find "$dir" -type d -exec chmod 2775 {} +
+          find "$dir" -type f -exec chgrp music-ingest {} +
+          find "$dir" -type f -exec chmod 0664 {} +
+          setfacl -R -m g:music-ingest:rwx "$dir"
+          find "$dir" -type d -exec setfacl -m d:g:music-ingest:rwX {} +
+          setfacl -R -m g:media:r-X "$dir"
+          find "$dir" -type d -exec setfacl -m d:g:media:r-X {} +
+        }
+        fixup "${mediaPaths.libraryDir}"
+        fixup "${mediaPaths.quarantineDir}"
+        fixup "${mediaPaths.untaggedDir}"
+        fixup "${mediaPaths.approvedDir}"
+      '';
+    };
   };
+
+  beetsServiceDefaults = {
+    Type = "oneshot";
+    User = "beets";
+    Group = "beets";
+    SupplementaryGroups = [ "music-ingest" "media" ];
+    WorkingDirectory = cfg.dataDir;
+    Environment = "BEETSDIR=${cfg.dataDir}";
+    ExecStartPost = [ "+${beetsRunners.permissionReconcile}/bin/beets-permission-reconcile" ];
+    UMask = "0002";
+    NoNewPrivileges = true;
+    PrivateTmp = true;
+    PrivateDevices = true;
+    ProtectSystem = "strict";
+    ProtectHome = true;
+    ProtectControlGroups = true;
+    ProtectKernelTunables = true;
+    ProtectKernelModules = true;
+    ProtectClock = true;
+    ProtectProc = "invisible";
+    RestrictSUIDSGID = true;
+    RestrictRealtime = true;
+    LockPersonality = true;
+    MemoryDenyWriteExecute = true;
+    SystemCallArchitectures = "native";
+  };
+
+  mkBeetsService = { name, description, conditionDir, execStart, mountFor, writePaths }:
+    assert builtins.isString name && name != "";
+    assert builtins.isString description;
+    assert builtins.isString conditionDir;
+    assert builtins.isString execStart;
+    assert builtins.isList mountFor;
+    assert builtins.isList writePaths;
+    {
+      inherit description;
+      unitConfig = {
+        RequiresMountsFor = mountFor;
+        ConditionPathIsDirectory = conditionDir;
+      };
+      after = [ "systemd-tmpfiles-setup.service" ];
+      serviceConfig = beetsServiceDefaults // {
+        ExecStart = execStart;
+        ReadWritePaths = writePaths ++ [ "/run/secrets/rendered" ];
+      };
+    };
+
+  aclForDir = dir: [
+    "a+ ${dir} - - - - group:music-ingest:rwx"
+    "a+ ${dir} - - - - default:group:music-ingest:rwX"
+    "a+ ${dir} - - - - group:media:r-X"
+    "a+ ${dir} - - - - default:group:media:r-X"
+  ];
+
 in
 {
   options.services.beets-inbox.dataDir = lib.mkOption {
@@ -171,35 +283,15 @@ in
       })
     ];
 
-    sops.templates."beets-config.yaml" = {
-      owner = "beets";
-      group = "beets";
-      mode = "0440";
-      content =
-        builtins.replaceStrings
-          [ "REPLACE_WITH_DISCOGS_USER_TOKEN" ]
-          [ config.sops.placeholder.beets_discogs_token ]
-          (builtins.readFile ../../scripts/beets-config.yaml);
-    };
+    sops.templates = builtins.listToAttrs (map (name: {
+      inherit name;
+      value = mkSopsTemplate name;
+    }) beetsConfigNames);
 
-    sops.templates."beets-approved-config.yaml" = {
-      owner = "beets";
-      group = "beets";
-      mode = "0440";
-      content =
-        builtins.replaceStrings
-          [ "REPLACE_WITH_DISCOGS_USER_TOKEN" ]
-          [ config.sops.placeholder.beets_discogs_token ]
-          (builtins.readFile ../../scripts/beets-approved-config.yaml);
-    };
-
-    sops.secrets.beets_discogs_token = {
-      sopsFile = cfg.secretFiles.host;
-      key = "beets/discogs_token";
-      path = "/run/secrets/beets.discogs_token";
-      owner = "beets";
-      group = "beets";
-    };
+    sops.secrets = builtins.listToAttrs (map (e: {
+      name = e.secretName;
+      value = mkSopsSecret e;
+    }) beetsSecretEntries);
 
     users.groups.beets = { };
     users.users.beets = {
@@ -207,160 +299,62 @@ in
       group = "beets";
       home = cfg.dataDir;
       createHome = false;
-      extraGroups = [
-        "music-ingest"
-        "media"
-      ];
+      extraGroups = [ "music-ingest" "media" ];
     };
 
     environment.systemPackages = [
       beetsRuntime
-      beetsInboxRunner
-      beetsQuarantineApprovedRunner
-      beetsPermissionReconcile
+      beetsRunners.inbox
+      beetsRunners.quarantineApproved
+      beetsRunners.quarantine
+      beetsRunners.interactive
+      beetsRunners.permissionReconcile
+      beetsRunners.convert
+      beetsRunners.reconcile
     ];
 
-    systemd.tmpfiles.rules = [
-      "d ${config.services.beets-inbox.dataDir} 0750 beets beets - -"
-      "d ${config.services.beets-inbox.dataDir}/state 0750 beets beets - -"
-      "d ${config.services.beets-inbox.dataDir}/logs 0750 beets beets - -"
-      "a+ ${config.services.beets-inbox.dataDir}/logs - - - - user:dev:r-x"
-      "a+ ${config.services.beets-inbox.dataDir}/logs - - - - default:user:dev:r-x"
-      "d ${mediaLibraryDir} 2775 root music-ingest - -"
-      "a+ ${mediaLibraryDir} - - - - group:music-ingest:rwx"
-      "a+ ${mediaLibraryDir} - - - - default:group:music-ingest:rwX"
-      "a+ ${mediaLibraryDir} - - - - group:media:r-X"
-      "a+ ${mediaLibraryDir} - - - - default:group:media:r-X"
-      "d ${mediaQuarantineDir} 2775 root music-ingest - -"
-      "d ${mediaUntaggedDir} 2775 root music-ingest - -"
-      "d ${mediaApprovedDir} 2775 root music-ingest - -"
-      "a+ ${mediaUntaggedDir} - - - - group:music-ingest:rwx"
-      "a+ ${mediaUntaggedDir} - - - - default:group:music-ingest:rwX"
-      "a+ ${mediaUntaggedDir} - - - - group:media:r-X"
-      "a+ ${mediaUntaggedDir} - - - - default:group:media:r-X"
-      "a+ ${mediaApprovedDir} - - - - group:music-ingest:rwx"
-      "a+ ${mediaApprovedDir} - - - - default:group:music-ingest:rwX"
-      "a+ ${mediaApprovedDir} - - - - group:media:r-X"
-      "a+ ${mediaApprovedDir} - - - - default:group:media:r-X"
-    ];
+    systemd.tmpfiles.rules =
+      [
+        "d ${cfg.dataDir} 0750 beets beets - -"
+        "d ${cfg.dataDir}/state 0750 beets beets - -"
+        "d ${cfg.dataDir}/logs 0750 beets beets - -"
+        "a+ ${cfg.dataDir}/logs - - - - user:dev:r-x"
+        "a+ ${cfg.dataDir}/logs - - - - default:user:dev:r-x"
+        "d ${mediaPaths.untaggedDir} 2775 root music-ingest - -"
+        "d ${mediaPaths.approvedDir} 2775 root music-ingest - -"
+      ]
+      ++ aclForDir mediaPaths.untaggedDir
+      ++ aclForDir mediaPaths.approvedDir;
 
-    systemd.services.beets-inbox-run = {
+    systemd.services.beets-inbox-run = mkBeetsService {
+      name = "beets-inbox-run";
       description = "Beets all-inbox native album import worker";
-      unitConfig.RequiresMountsFor = [
-        config.services.beets-inbox.dataDir
-        cfg.mediaRoot
-        mediaInboxDir
-        mediaLibraryDir
-        mediaUntaggedDir
-        mediaApprovedDir
-      ];
-      unitConfig.ConditionPathIsDirectory = mediaInboxDir;
-      after = [
-        "systemd-tmpfiles-setup.service"
-      ];
-      serviceConfig = {
-        Type = "oneshot";
-        User = "beets";
-        Group = "beets";
-        SupplementaryGroups = [
-          "music-ingest"
-          "media"
-        ];
-        WorkingDirectory = cfg.dataDir;
-        Environment = "BEETSDIR=${cfg.dataDir}";
-        ExecStart = "${beetsInboxRunner}/bin/beets-inbox-runner ${mediaInboxDir}";
-        ExecStartPost = [ "+${beetsPermissionReconcile}/bin/beets-permission-reconcile" ];
-        UMask = "0002";
-        NoNewPrivileges = true;
-        PrivateTmp = true;
-        PrivateDevices = true;
-        ProtectSystem = "strict";
-        ProtectHome = true;
-        ProtectControlGroups = true;
-        ProtectKernelTunables = true;
-        ProtectKernelModules = true;
-        ProtectClock = true;
-        ProtectProc = "invisible";
-        RestrictSUIDSGID = true;
-        RestrictRealtime = true;
-        LockPersonality = true;
-        MemoryDenyWriteExecute = true;
-        SystemCallArchitectures = "native";
-        ReadWritePaths = [
-          cfg.dataDir
-          mediaInboxDir
-          mediaLibraryDir
-          mediaUntaggedDir
-          mediaApprovedDir
-        ];
-      };
+      conditionDir = mediaPaths.inboxDir;
+      execStart = "${beetsRunners.inbox}/bin/beets-inbox-runner ${mediaPaths.inboxDir}";
+      mountFor = [ cfg.dataDir cfg.mediaRoot mediaPaths.inboxDir mediaPaths.libraryDir mediaPaths.untaggedDir mediaPaths.approvedDir ];
+      writePaths = [ cfg.dataDir mediaPaths.inboxDir mediaPaths.libraryDir mediaPaths.untaggedDir mediaPaths.approvedDir ];
     };
 
-    systemd.services.beets-quarantine-promote-run = {
+    systemd.services.beets-quarantine-promote-run = mkBeetsService {
+      name = "beets-quarantine-promote-run";
       description = "Beets quarantine approved promotion worker";
-      unitConfig.RequiresMountsFor = [
-        cfg.dataDir
-        cfg.mediaRoot
-        mediaLibraryDir
-        mediaApprovedDir
-      ];
-      unitConfig.ConditionPathIsDirectory = mediaApprovedDir;
-      after = [
-        "systemd-tmpfiles-setup.service"
-      ];
-      serviceConfig = {
-        Type = "oneshot";
-        User = "beets";
-        Group = "beets";
-        SupplementaryGroups = [
-          "music-ingest"
-          "media"
-        ];
-        WorkingDirectory = cfg.dataDir;
-        Environment = "BEETSDIR=${cfg.dataDir}";
-        ExecStart = "${beetsQuarantineApprovedRunner}/bin/beets-quarantine-approved-runner ${mediaApprovedDir}";
-        ExecStartPost = [ "+${beetsPermissionReconcile}/bin/beets-permission-reconcile" ];
-        UMask = "0002";
-        NoNewPrivileges = true;
-        PrivateTmp = true;
-        PrivateDevices = true;
-        ProtectSystem = "strict";
-        ProtectHome = true;
-        ProtectControlGroups = true;
-        ProtectKernelTunables = true;
-        ProtectKernelModules = true;
-        ProtectClock = true;
-        ProtectProc = "invisible";
-        RestrictSUIDSGID = true;
-        RestrictRealtime = true;
-        LockPersonality = true;
-        MemoryDenyWriteExecute = true;
-        SystemCallArchitectures = "native";
-        ReadWritePaths = [
-          cfg.dataDir
-          mediaLibraryDir
-          mediaApprovedDir
-        ];
-      };
+      conditionDir = mediaPaths.approvedDir;
+      execStart = "${beetsRunners.quarantineApproved}/bin/beets-quarantine-approved-runner ${mediaPaths.approvedDir}";
+      mountFor = [ cfg.dataDir cfg.mediaRoot mediaPaths.libraryDir mediaPaths.approvedDir ];
+      writePaths = [ cfg.dataDir mediaPaths.libraryDir mediaPaths.approvedDir ];
     };
 
     systemd.paths.beets-inbox-watch = {
       enable = false;
-      unitConfig.RequiresMountsFor = [
-        cfg.mediaRoot
-        mediaInboxDir
-      ];
-      pathConfig.PathModified = mediaInboxDir;
+      unitConfig.RequiresMountsFor = [ cfg.mediaRoot mediaPaths.inboxDir ];
+      pathConfig.PathModified = mediaPaths.inboxDir;
       pathConfig.Unit = "beets-inbox-run.service";
     };
 
     systemd.paths.beets-quarantine-promote-watch = {
       enable = false;
-      unitConfig.RequiresMountsFor = [
-        cfg.mediaRoot
-        mediaApprovedDir
-      ];
-      pathConfig.PathModified = mediaApprovedDir;
+      unitConfig.RequiresMountsFor = [ cfg.mediaRoot mediaPaths.approvedDir ];
+      pathConfig.PathModified = mediaPaths.approvedDir;
       pathConfig.Unit = "beets-quarantine-promote-run.service";
     };
 

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -98,7 +98,10 @@ in
       enable = true;
       dataDir = lib.mkDefault "/srv/data/syncthing";
       configDir = lib.mkDefault "/srv/data/syncthing/config";
+      guiAddress = lib.mkDefault "0.0.0.0:8384";
       openDefaultPorts = false;
+      overrideDevices = lib.mkDefault true;
+      overrideFolders = lib.mkDefault true;
       settings.devices = cfg.deviceTargets;
       settings.folders = folderSettings;
     };

--- a/modules/storage/disko-single-disk-split.nix
+++ b/modules/storage/disko-single-disk-split.nix
@@ -1,0 +1,104 @@
+{ lib, config, ... }:
+{
+  options."disko-root-extra" = lib.mkOption {
+    type = lib.types.str;
+    default = "20G";
+    description = "Size for the root partition on single-disk split hosts.";
+  };
+
+  options."disko-data-size" = lib.mkOption {
+    type = lib.types.str;
+    default = "28G";
+    description = "Size for the /srv/data partition on single-disk split hosts.";
+  };
+
+  options."disko-nix-size" = lib.mkOption {
+    type = lib.types.str;
+    default = "45G";
+    description = "Size for the /nix partition on single-disk split hosts.";
+  };
+
+  config.disko.devices.disk.main = {
+    type = "disk";
+    content = {
+      type = "gpt";
+      partitions = {
+        bios_grub = {
+          size = "1M";
+          type = "EF02";
+        };
+
+        ESP = {
+          size = "512M";
+          type = "EF00";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+            mountOptions = [ "umask=0077" ];
+          };
+        };
+
+        root = {
+          size = lib.mkDefault config.disko-root-extra;
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            extraArgs = [
+              "-L"
+              "rootfs"
+            ];
+            mountpoint = "/";
+          };
+        };
+
+        data = {
+          size = lib.mkDefault config.disko-data-size;
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            extraArgs = [
+              "-L"
+              "srv-data"
+            ];
+            mountpoint = "/srv/data";
+            mountOptions = [
+              "nofail"
+              "x-systemd.device-timeout=10s"
+            ];
+          };
+        };
+
+        nix = {
+          size = lib.mkDefault config.disko-nix-size;
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            extraArgs = [
+              "-L"
+              "nix"
+            ];
+            mountpoint = "/nix";
+          };
+        };
+
+        media = {
+          size = "100%";
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            extraArgs = [
+              "-L"
+              "srv-media"
+            ];
+            mountpoint = "/srv/media";
+            mountOptions = [
+              "nofail"
+              "x-systemd.device-timeout=10s"
+            ];
+          };
+        };
+      };
+    };
+  };
+}

--- a/openspec/changes/archive/2026-05-06-reshape-oci-melb-1-storage/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-06-reshape-oci-melb-1-storage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/archive/2026-05-06-reshape-oci-melb-1-storage/design.md
+++ b/openspec/changes/archive/2026-05-06-reshape-oci-melb-1-storage/design.md
@@ -1,0 +1,52 @@
+## Overview
+
+This change makes the recovered `oci-melb-1` layout the canonical declarative baseline and closes the operational gaps exposed during rescue. The design keeps the recovered partitioning simple: root, data, nix, and media remain separate ext4 filesystems on the OCI boot volume, referenced by stable partlabels. The follow-up work focuses on three areas: declarative storage layout fidelity, media/tmpfiles consistency, and operator recovery documentation.
+
+## Goals
+
+- Preserve the working single-disk recovery layout in repository state.
+- Ensure the evaluated host filesystem contract matches the real OCI partition map.
+- Remove duplicate tmpfiles directory ownership declarations for shared media paths.
+- Ensure required media/service directories are created declaratively on boot.
+- Capture the proven offline recovery sequence as canonical operator guidance.
+
+## Non-Goals
+
+- Repartitioning `oci-melb-1` again.
+- Introducing a second-disk storage model for the first host.
+- Redesigning the whole music application stack.
+- Changing secret topology beyond what the recovery/runbook needs.
+
+## Storage Shape
+
+The canonical `oci-melb-1` layout after recovery is:
+
+- EFI system partition on the OCI boot volume
+- ext4 root on `disk-main-root`
+- ext4 service-state filesystem on `disk-main-data` mounted at `/srv/data`
+- ext4 Nix store filesystem on `disk-main-nix` mounted at `/nix`
+- ext4 media filesystem on `disk-main-media` mounted at `/srv/media`
+
+This layout remains host-specific and is expressed through `disko-single-disk.nix` plus host-provided sizing options.
+
+## Media Directory Ownership Strategy
+
+The current repo defines some media directories from multiple modules. The cleanup will consolidate directory-creation ownership so each shared media path has one authoritative tmpfiles owner while other modules may still layer ACL or marker-file behavior. This avoids duplicate tmpfiles warnings while preserving the intended permissions model for Syncthing, Beets, and related services.
+
+## Recovery Runbook Strategy
+
+The runbook will document the validated rescue flow:
+
+1. Attach the broken boot volume to a rescue instance.
+2. Mount root, `/nix`, `/srv/media`, and the ESP.
+3. Bind `/dev`, `/proc`, `/sys`, `/run` and provide DNS in chroot.
+4. Build the target system closure with sandbox disabled when required in rescue chroot.
+5. Run `switch-to-configuration boot` with the mounted ESP.
+6. Unmount cleanly, reattach the boot volume, and validate host boot plus mount/service health.
+
+## Validation Plan
+
+- Evaluate `nixosConfigurations.oci-melb-1.config.fileSystems` and relevant tmpfiles output.
+- Run `nix flake check` using a path source so untracked files required by evaluation are included.
+- Verify no duplicate tmpfiles directory rules remain for canonical shared media directories.
+- Confirm documented post-recovery operator checks cover bootability, mounts, and key service paths.

--- a/openspec/changes/archive/2026-05-06-reshape-oci-melb-1-storage/proposal.md
+++ b/openspec/changes/archive/2026-05-06-reshape-oci-melb-1-storage/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`oci-melb-1` was recovered after a live storage migration left `/nix` unavailable during boot, which exposed gaps between the intended single-disk storage layout, the declarative repo state, and the operator recovery path. We need to codify the new single-disk shape, remove storage-setup drift that causes duplicate tmpfiles behavior, and document the validated recovery workflow so future storage changes stay recoverable.
+
+## What Changes
+
+- Declare the recovered `oci-melb-1` single-disk layout as the canonical host storage baseline, including dedicated `/nix`, `/srv/data`, and `/srv/media` mounts on the OCI boot volume.
+- Tighten storage-related directory creation and mount expectations so media and service-state paths are created declaratively without duplicate tmpfiles ownership rules.
+- Add an operator recovery runbook covering offline rebuild, chroot rescue requirements, ESP mounting, and post-recovery validation.
+- Add validation tasks to confirm the reshaped host configuration, tmpfiles behavior, and key music/media paths evaluate cleanly.
+
+## Capabilities
+
+### New Capabilities
+- `host-storage-recovery`: Canonical recovery and reshape workflow for hosts that move storage layout while preserving bootability and service data contracts.
+
+### Modified Capabilities
+- `bootstrap-storage`: Update the storage contract so the `oci-melb-1` baseline can declare `/`, `/nix`, `/srv/data`, and `/srv/media` on one disk using stable partition labels.
+- `operations`: Extend operator recovery guidance with the validated offline rescue and post-recovery verification workflow.
+
+## Impact
+
+- Affected code: `hosts/oci-melb-1/default.nix`, `modules/storage/disko-single-disk.nix`, music/media-related modules, and docs/runbooks.
+- Affected systems: `oci-melb-1` storage layout, tmpfiles-driven directory creation, offline recovery workflow.
+- Dependencies: existing `disko`, NixOS tmpfiles behavior, OCI rescue-instance workflow, and current music application modules.

--- a/openspec/changes/archive/2026-05-06-reshape-oci-melb-1-storage/specs/bootstrap-storage/spec.md
+++ b/openspec/changes/archive/2026-05-06-reshape-oci-melb-1-storage/specs/bootstrap-storage/spec.md
@@ -1,0 +1,9 @@
+## MODIFIED Requirements
+
+### Requirement: Disk layout is encoded in disko modules
+Host disk and filesystem layout SHALL be represented in disko module definitions.
+
+#### Scenario: Storage plan is evaluated
+- **WHEN** storage modules are rendered for a host
+- **THEN** partition/filesystem/mount structure is derived declaratively
+- **AND** `oci-melb-1` can declare root, `/srv/data`, `/nix`, and `/srv/media` as stable labeled filesystems on the OCI boot volume

--- a/openspec/changes/archive/2026-05-06-reshape-oci-melb-1-storage/specs/host-storage-recovery/spec.md
+++ b/openspec/changes/archive/2026-05-06-reshape-oci-melb-1-storage/specs/host-storage-recovery/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Recovered host storage reshapes SHALL be captured declaratively
+When a host storage layout is recovered or reshaped, the repository SHALL record the resulting mount and partition contract as canonical host state.
+
+#### Scenario: A recovered host layout is reviewed
+- **WHEN** the recovered host configuration and storage module are inspected
+- **THEN** the rendered filesystem contract matches the intended recovered layout
+- **AND** the host no longer depends on stale pre-recovery disk assumptions
+
+### Requirement: Shared media directories SHALL have one declarative directory owner
+Shared media paths used by multiple services SHALL have one authoritative directory-creation definition, while other modules may layer ACLs or marker files without redefining the same directory ownership contract.
+
+#### Scenario: Tmpfiles rules are rendered for shared media paths
+- **WHEN** tmpfiles rules are evaluated for paths such as `/srv/media/library` or `/srv/media/quarantine`
+- **THEN** each shared directory has a single canonical directory-creation rule
+- **AND** additional ACL or marker-file rules do not produce duplicate directory ownership declarations
+
+### Requirement: Recovery workflows SHALL include offline rebuild guidance
+Host recovery after storage disruption SHALL have a documented offline rebuild workflow that covers rescue mounting, chroot requirements, bootloader update prerequisites, and post-recovery validation.
+
+#### Scenario: Operator follows the recovery runbook
+- **WHEN** an operator performs break-glass recovery from a rescue instance
+- **THEN** the runbook includes required mounts for root, `/nix`, `/boot`, and service filesystems as applicable
+- **AND** it includes the commands needed to rebuild bootable system state and verify successful recovery

--- a/openspec/changes/archive/2026-05-06-reshape-oci-melb-1-storage/specs/operations/spec.md
+++ b/openspec/changes/archive/2026-05-06-reshape-oci-melb-1-storage/specs/operations/spec.md
@@ -1,0 +1,9 @@
+## MODIFIED Requirements
+
+### Requirement: Break-glass baseline and rollback paths are documented
+Operators SHALL capture baseline state before risky changes and SHALL have documented rollback and recovery procedures, including offline rescue rebuilds for storage-related failures.
+
+#### Scenario: Recovery is required
+- **WHEN** SSH, Tailscale, or boot viability degrades after a storage or mount change
+- **THEN** break-glass steps and generation rollback commands are available to restore access
+- **AND** the workflow includes offline rescue rebuild guidance for restoring `/nix`, mounting the ESP, and reinstalling a bootable generation when live recovery is no longer possible

--- a/openspec/changes/archive/2026-05-06-reshape-oci-melb-1-storage/tasks.md
+++ b/openspec/changes/archive/2026-05-06-reshape-oci-melb-1-storage/tasks.md
@@ -1,0 +1,16 @@
+## 1. Canonical storage shape
+
+- [x] 1.1 Confirm `oci-melb-1` host wiring and `disko-single-disk` options match the recovered single-disk partition and mount layout.
+- [x] 1.2 Validate rendered filesystem outputs for `/`, `/boot`, `/nix`, `/srv/data`, and `/srv/media` against the intended OCI layout.
+
+## 2. Media/tmpfiles cleanup
+
+- [x] 2.1 Identify duplicate tmpfiles directory-creation ownership rules for shared media paths.
+- [x] 2.2 Refactor the relevant modules so shared media directories are created once declaratively while ACL and marker-file behavior still renders correctly.
+- [x] 2.3 Verify Syncthing/music-related paths (`/srv/media/library`, `/srv/media/quarantine`, `/srv/media/inbox`, markers, ACL hooks) still evaluate and create correctly.
+
+## 3. Recovery documentation and validation
+
+- [x] 3.1 Document the validated rescue-instance recovery workflow for storage/mount failures.
+- [x] 3.2 Run repo validation (`nix flake check` with appropriate source mode and targeted eval checks) and fix any issues introduced by this change.
+- [x] 3.3 Run `openspec validate reshape-oci-melb-1-storage --strict` and confirm the change is ready for implementation/archive flow.

--- a/openspec/specs/bootstrap-storage/spec.md
+++ b/openspec/specs/bootstrap-storage/spec.md
@@ -3,9 +3,7 @@
 ## Purpose
 
 Define declarative bootstrap and storage contracts for host installation, mount layout, and provider-aware disk composition.
-
 ## Requirements
-
 ### Requirement: Bootstrap workflow is declarative
 Host bootstrap SHALL be driven by repository-defined declarative workflows.
 
@@ -19,6 +17,7 @@ Host disk and filesystem layout SHALL be represented in disko module definitions
 #### Scenario: Storage plan is evaluated
 - **WHEN** storage modules are rendered for a host
 - **THEN** partition/filesystem/mount structure is derived declaratively
+- **AND** `oci-melb-1` can declare root, `/srv/data`, `/nix`, and `/srv/media` as stable labeled filesystems on the OCI boot volume
 
 ### Requirement: Service-state and media mounts are separated
 The storage model SHALL separate service-state and media mounts with predictable mount points.
@@ -33,3 +32,4 @@ Provider-specific storage/bootstrap defaults SHALL remain isolated from reusable
 #### Scenario: Multiple providers are supported
 - **WHEN** provider modules are compared
 - **THEN** provider-specific assumptions appear only in provider/host composition layers
+

--- a/openspec/specs/host-storage-recovery/spec.md
+++ b/openspec/specs/host-storage-recovery/spec.md
@@ -1,0 +1,29 @@
+# host-storage-recovery Specification
+
+## Purpose
+TBD - created by archiving change reshape-oci-melb-1-storage. Update Purpose after archive.
+## Requirements
+### Requirement: Recovered host storage reshapes SHALL be captured declaratively
+When a host storage layout is recovered or reshaped, the repository SHALL record the resulting mount and partition contract as canonical host state.
+
+#### Scenario: A recovered host layout is reviewed
+- **WHEN** the recovered host configuration and storage module are inspected
+- **THEN** the rendered filesystem contract matches the intended recovered layout
+- **AND** the host no longer depends on stale pre-recovery disk assumptions
+
+### Requirement: Shared media directories SHALL have one declarative directory owner
+Shared media paths used by multiple services SHALL have one authoritative directory-creation definition, while other modules may layer ACLs or marker files without redefining the same directory ownership contract.
+
+#### Scenario: Tmpfiles rules are rendered for shared media paths
+- **WHEN** tmpfiles rules are evaluated for paths such as `/srv/media/library` or `/srv/media/quarantine`
+- **THEN** each shared directory has a single canonical directory-creation rule
+- **AND** additional ACL or marker-file rules do not produce duplicate directory ownership declarations
+
+### Requirement: Recovery workflows SHALL include offline rebuild guidance
+Host recovery after storage disruption SHALL have a documented offline rebuild workflow that covers rescue mounting, chroot requirements, bootloader update prerequisites, and post-recovery validation.
+
+#### Scenario: Operator follows the recovery runbook
+- **WHEN** an operator performs break-glass recovery from a rescue instance
+- **THEN** the runbook includes required mounts for root, `/nix`, `/boot`, and service filesystems as applicable
+- **AND** it includes the commands needed to rebuild bootable system state and verify successful recovery
+

--- a/openspec/specs/operations/spec.md
+++ b/openspec/specs/operations/spec.md
@@ -31,11 +31,12 @@ The operator surface SHALL provide commands for host status, service logs, and i
 - **THEN** operators can verify Caddy edge status, certificate state, and effective route behavior for edge and upstream transport
 
 ### Requirement: Break-glass baseline and rollback paths are documented
-Operators SHALL capture baseline state before risky changes and SHALL have documented rollback/recovery procedures.
+Operators SHALL capture baseline state before risky changes and SHALL have documented rollback and recovery procedures, including offline rescue rebuilds for storage-related failures.
 
 #### Scenario: Recovery is required
-- **WHEN** SSH/Tailscale access degrades after change
+- **WHEN** SSH, Tailscale, or boot viability degrades after a storage or mount change
 - **THEN** break-glass steps and generation rollback commands are available to restore access
+- **AND** the workflow includes offline rescue rebuild guidance for restoring `/nix`, mounting the ESP, and reinstalling a bootable generation when live recovery is no longer possible
 
 ### Requirement: Host recipient management is operationalized
 Host key to age-recipient derivation SHALL be available via operator workflows with preview and update modes.
@@ -65,3 +66,4 @@ The operator contract SHALL require validation beyond successful backup completi
 #### Scenario: Backup validation is performed for a critical service
 - **WHEN** operators validate backup health for identity or SQLite-backed services
 - **THEN** validation includes restore-oriented verification steps rather than only timer/job success status
+


### PR DESCRIPTION
This pull request codifies the recovered single-disk storage layout for the `oci-melb-1` host, making it the canonical baseline in both code and documentation. It replaces the previous two-disk model with a declarative, single-disk partitioning scheme, ensures that shared media directories are created by a single authoritative tmpfiles rule, and documents the validated recovery and rescue workflow. The change includes updates to NixOS module wiring, new storage modules, and comprehensive specification and runbook documentation to close operational gaps exposed during the recent recovery.

**Storage layout and configuration changes:**
- Switched `oci-melb-1` from using `disko-root` (two-disk model) to `disko-single-disk-split.nix`, declaring root, `/nix`, `/srv/data`, and `/srv/media` as stable partitions on the OCI boot volume. Host-provided sizing options are now exposed for these partitions. [[1]](diffhunk://#diff-4954a017d14863dfe0431d74be4f50574b3d876bac9d7467697996a974e216baL24-R24) [[2]](diffhunk://#diff-5b773b86c1a1af14861447d1a5541a85a93ebffef94712c57a5446ec2f363979R1-R104) [[3]](diffhunk://#diff-4954a017d14863dfe0431d74be4f50574b3d876bac9d7467697996a974e216baL126-R128)
- Removed the secondary media disk reference and consolidated all storage on `/dev/sda`.
- Added and documented new storage sizing options: `disko-root-extra`, `disko-data-size`, and `disko-nix-size`. [[1]](diffhunk://#diff-4954a017d14863dfe0431d74be4f50574b3d876bac9d7467697996a974e216baL126-R128) [[2]](diffhunk://#diff-5b773b86c1a1af14861447d1a5541a85a93ebffef94712c57a5446ec2f363979R1-R104)

**Declarative directory and tmpfiles cleanup:**
- Refactored media directory creation so that each shared media path has a single authoritative tmpfiles owner, preventing duplicate directory-creation warnings, while still allowing other modules to layer ACLs or marker files. [[1]](diffhunk://#diff-5b26d2896573711b1d3b06fd8e131cca2351d03739b15e3546308e72aba46b71L177-R183) [[2]](diffhunk://#diff-5b26d2896573711b1d3b06fd8e131cca2351d03739b15e3546308e72aba46b71R291)
- Updated Syncthing/music-related modules to ensure correct rendering of media and service-state directories.

**Operational and recovery improvements:**
- Added and enabled a `hostRecovery` service with declarative rescue user, secret, and scheduled reboot for improved break-glass recovery.
- Documented the full offline rescue and rebuild workflow in the runbook and specification, including requirements for mounting, chroot, bootloader updates, and post-recovery validation. [[1]](diffhunk://#diff-fdf81ce5f786d51b08e699aab5f966275ac14b88659ee49fc0d70ac0c1ec6aa0R1-R52) [[2]](diffhunk://#diff-9a1df4934a5e3def300d7f79a8ee30a93c9f9aa0152a194bee6d2fcd9c923eaaR1-R25) [[3]](diffhunk://#diff-c0faab40666f281f38a23089a55d3d6af584fa5ade7d6869c44502e3ff261a3cR1-R25) [[4]](diffhunk://#diff-5c83650fef7e3724998890f3371db329d453f70171aa46b70e55557e1b40d3ccR1-R9)

**Specification and compliance updates:**
- Archived the change as an OpenSpec, updating and extending the `bootstrap-storage`, `host-storage-recovery`, and `operations` specs to reflect the new canonical storage contract and recovery requirements. [[1]](diffhunk://#diff-30b5f18ce511fb1efe9e293904cccd16d44e75937b48f7a6745fd8c5b7d3af5dR1-R2) [[2]](diffhunk://#diff-5dd501abc99bad0d3592225020b6a299da51d34ea22dd22435ad1ca914d11a38R1-R9) [[3]](diffhunk://#diff-c0faab40666f281f38a23089a55d3d6af584fa5ade7d6869c44502e3ff261a3cR1-R25) [[4]](diffhunk://#diff-5c83650fef7e3724998890f3371db329d453f70171aa46b70e55557e1b40d3ccR1-R9) [[5]](diffhunk://#diff-fb47108201469b631fb9ab8bdc847f70fe99ac08469d239d1cb192d9f7f6d78cR20) [[6]](diffhunk://#diff-69b04fbf9a8bb0c0289fab0e175f419e1bb0bfb4308d27146ac8e6dacefe1184R1-R29)

**Validation and tasks:**
- Added validation tasks to ensure the rendered filesystem layout, tmpfiles rules, and recovery documentation match the intended state and pass repository checks.

These changes together ensure that the repository accurately represents the real-world, recoverable storage layout for `oci-melb-1`, reduces operational risk, and provides clear guidance for future recovery scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Syncthing configuration options: GUI address, device override, and folder override settings
  * Introduced host recovery service for automated backup and rescue capabilities
  * Added media permission reconciliation service for directory access management

* **Documentation**
  * New storage recovery specification and operational runbooks
  * Recovery procedures for offline rescue and system restoration scenarios

* **Chores**
  * Updated storage layout configuration for improved disk partitioning and sizing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->