### PR TITLE
Feat/host recovery baseline

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -67,7 +67,7 @@ creation_rules:
           - *owner_age
           - *do_admin_1_age
 
-  # Host exception scopes: system (host/bootstrap-only)
+  # Host exception scopes: system (host/bootstrap-only, including recovery password hashes)
   - path_regex: ^secrets/hosts/oci-melb-1/system\.ya?ml$
     key_groups:
       - age:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,6 +129,7 @@ Standalone service scope:
 Host exception scope:
 
 - `secrets/hosts/<host>/system.yaml` — host-only bootstrap/system secrets (e.g. Tailscale auth key, SSH identities)
+  - this scope now also carries host-only recovery password hash material for console break-glass users when that recovery baseline is enabled
 - `secrets/hosts/<host>/oidc.yaml` — cross-host OIDC handshake secrets where both the app host and identity provider host need to decrypt
 
 Fleet-shared scope:
@@ -174,13 +175,22 @@ Accepted advanced alternative:
 
 Current decision:
 
+- one dedicated Nix store filesystem mounted at `/nix` on `oci-melb-1`
 - one persistent service-state mount on the host (`/srv/data`)
 - one dedicated media filesystem mounted at `/srv/media`
 - service state organized under subdirectories on `/srv/data`
 
+Recovered `oci-melb-1` single-disk baseline:
+
+- the OCI boot volume now carries the EFI system partition plus labeled ext4 filesystems for `/`, `/srv/data`, `/nix`, and `/srv/media`
+- `modules/storage/disko-single-disk.nix` is the canonical storage boundary for that recovered host shape
+- host-specific sizing stays in `hosts/oci-melb-1/default.nix`, while the partition/mount contract remains declarative in the storage module
+
 Initial media/data flow:
 
 - Syncthing manages both `/srv/media/library` and `/srv/media/quarantine` directly
+- `modules/applications/music.nix` is the canonical owner for creating shared media roots (`/srv/media`, `/srv/media/inbox`, `/srv/media/library`, `/srv/media/quarantine`, `.versions`)
+- lower-level service modules may add ACLs, marker files, or service-specific subdirectories, but do not redefine those shared root directory ownership contracts
 - SoulSync is the primary ingest and promotion control-plane service
 - Tagr is available as an operator-invoked manual metadata/cover fallback editor against canonical media paths
 - `/srv/media` remains the authoritative shared media root
@@ -258,6 +268,14 @@ Current model:
 - Bifrost baseline mode is file-driven and host-local on `oci-melb-1`; `config_store`, UI-managed config mutation, and other runtime-mutated control-plane state are intentionally out of baseline scope
 - Repo-owned AI gateway aliases (`shrublab-text`, `shrublab-image`, `shrublab-embedding`, `shrublab-fallback`) sit behind one host-local OpenAI-compatible endpoint for downstream consumers such as Karakeep
 
+Recovery posture:
+
+- normal operator access remains Tailscale-first over SSH
+- both active hosts may enable a console-only `rescue` user for provider/serial-console break-glass access when the normal network path is unavailable
+- the `rescue` user is password-authenticated for local console use, denied for SSH login, and remains separate from the normal identity-backed admin flow
+- host recovery secret registration remains feature-owned by `modules/shared/host-recovery.nix`, while hosts only bind the host secret file path and enable the feature
+- recovery readiness is exercised with a declared weekly reboot timer so console/login regressions are more likely to surface during routine operations rather than only during an outage
+
 ## Admin Surface Model
 
 Current admin-service shape:
@@ -297,6 +315,7 @@ Bootstrap and rollout order:
 - regular host updates via `deploy-rs` (`just deploy <host>`)
 - dry-activation and validation via `just activate <host>` and `just check`
 - remote network-owner cutovers are installed with `deploy-rs --boot` and applied on reboot rather than live-switched over SSH
+- recovery baseline rollouts must verify the `rescue` user contract, scheduled reboot timer, and rollback path before the change is treated as complete
 
 Fleet tooling posture:
 
@@ -314,6 +333,14 @@ Operator commands:
 - dry-activate: `just activate oci-melb-1`
 - checks: `just check`
 - backups: `just backup-init <host>`, `just backup-run <host>`, `just backup-check <host>`, `just backup-prune <host>`
+
+Recovery verification checklist:
+
+- confirm `services.hostRecovery` is enabled on the target host and points at the host-scoped `system.yaml` secret file
+- confirm the `rescue` account exists, is intended for console-only use, and cannot be used for SSH login
+- confirm `host-recovery-reboot.timer` is present with the expected weekly cadence
+- keep provider/serial console access available until the new generation has been verified
+- for `oci-melb-1`, note that some local builds on the x86_64 admin machine remain limited by non-substitutable `aarch64-linux` derivations; use remote/host-side validation when a full local build cannot complete
 
 Note: `just deploy` takes positional host arguments (`just deploy oci-melb-1`), not `host=...`.
 

--- a/docs/context-history.md
+++ b/docs/context-history.md
@@ -49,6 +49,13 @@ Operational lesson captured during `do-admin-1` networking recovery:
 - migrating that host to declarative `systemd-networkd` required matching the observed static `ens3`/`ens4` addresses instead of assuming DHCP
 - the failed attempt was caused by doing a live SSH `switch` during network-owner handoff; the cutover succeeded when installed with `deploy-rs --boot` and applied on reboot
 
+Follow-on recovery lesson captured during host-recovery implementation:
+
+- the real missing break-glass path was a console-capable password-authenticated local user, not another normal SSH identity and not an immediate initrd SSH rollout
+- the chosen baseline is a console-only `rescue` user plus a weekly reboot exercise, with initrd SSH deferred until host-specific early-boot networking assumptions are worth validating separately
+- recovery secret wiring was intentionally moved into the shared recovery module so hosts stay thin and feature-owned secret contracts remain the norm
+- local validation is asymmetric: `do-admin-1` can be built on the x86_64 admin machine, while `oci-melb-1` may still require host-side or remote validation when non-substitutable `aarch64-linux` derivations prevent a full local build
+
 ## Security And Secrets Direction
 
 The conversation converged on blast-radius secrets management:
@@ -67,9 +74,17 @@ Bootstrap nuance that was discussed in depth:
 Current operational posture chosen in planning:
 
 - one persistent data mount
+- one dedicated `/nix` filesystem on the recovered `oci-melb-1` single-disk layout
 - Syncthing bidirectional mode with safety/versioning controls
 - Navidrome reads directly from sync-managed media path
 - no duplicate staging dataset initially to avoid unnecessary storage usage
+
+Recovery lesson now captured in active context:
+
+- a live migration that removed the old `/nix` before the new mount was boot-valid broke the host hard enough to require OCI rescue-instance recovery
+- the validated break-glass repair path was: attach boot volume to rescue VM, mount root + `/nix` + ESP, chroot with working `/dev` `/proc` `/sys` `/run` + DNS, build with sandbox disabled where needed, then run `switch-to-configuration boot`
+- the resulting declarative baseline for `oci-melb-1` is a single OCI boot volume carrying labeled filesystems for `/`, `/srv/data`, `/nix`, and `/srv/media`
+- shared media root directories are now intended to have one canonical tmpfiles owner in the application composition layer, with lower-level services only layering ACL or marker behavior
 
 Future-facing but deferred:
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -112,6 +112,35 @@ Rationale:
 - reduces complexity and storage duplication
 - delayed ingest/pipeline split can be introduced when processing needs are concrete
 
+## D-032: `oci-melb-1` uses a recovered single-disk runtime layout with dedicated `/nix`
+
+Status: Accepted
+
+Decision:
+
+- `oci-melb-1` now runs with `/`, `/srv/data`, `/nix`, and `/srv/media` as labeled filesystems on the OCI boot volume
+- `modules/storage/disko-single-disk.nix` is the canonical declarative layout for that host shape
+- `/nix` remains a dedicated filesystem rather than a bind-mount into another service-data path
+
+Rationale:
+
+- the previous root-only layout was too small for real host operation and recovery
+- the validated rescue flow proved the single-disk labeled-filesystem shape is workable and recoverable on OCI
+
+## D-033: Shared music/media roots have one declarative directory owner
+
+Status: Accepted
+
+Decision:
+
+- `modules/applications/music.nix` owns creation of shared media roots such as `/srv/media/inbox`, `/srv/media/library`, and `/srv/media/quarantine`
+- leaf modules like Syncthing and Beets may add marker files, ACLs, or service-specific children, but do not redefine the same shared directory ownership contract
+
+Rationale:
+
+- avoids duplicate tmpfiles warnings and ownership drift
+- keeps cross-service storage policy in the application composition layer where shared media semantics are already defined
+
 ## D-009: Deployment tooling sequence
 
 Status: Accepted
@@ -549,6 +578,24 @@ Rationale:
 - a live SSH deployment can lose transport while activation stops the old network owner, even if the target generation itself is valid
 - applying the cutover at boot keeps the current session stable until the new generation takes control during early boot, where console rollback remains available
 - `do-admin-1`'s current provider-assigned addresses are stable enough for explicit declaration and matched the observed healthy runtime state better than the attempted DHCP handoff
+
+## D-034: Remote hosts keep a console-only rescue baseline with weekly exercise
+
+Status: Accepted
+
+Decision:
+
+- active remote hosts keep a declarative `rescue` user for provider or serial console break-glass access when normal SSH/Tailscale paths are unavailable
+- the `rescue` user is console-only, password-authenticated, separate from the normal identity-backed admin flow, and requires sudo with password rather than inheriting the default passwordless wheel posture
+- the recovery feature owns its own secret contract and reads the host-scoped rescue password hash from `secrets/hosts/<host>/system.yaml`, while host files remain thin and only enable/bind the feature
+- active hosts run a weekly reboot exercise through the shared recovery module so the break-glass baseline is exercised routinely
+
+Rationale:
+
+- the practical outage gap was lack of a local password-authenticated console path after network or SSH failure, not lack of another routine SSH identity
+- keeping the rescue user separate from normal admin access preserves the private-first identity model while making the break-glass path auditable and easy to rotate
+- module-owned secret wiring matches the repository's feature-oriented composition model better than host-owned `sops.secrets` declarations for recovery internals
+- a routine reboot exercise provides earlier feedback on boot/login regressions than waiting for a real outage
 
 ## Open Questions (Intentional)
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -70,9 +70,11 @@ Track C: Host and storage baseline
 
 - establish reliable host bootstrap path
 - stage remote network-owner transitions so access survives the change window
-- apply one-mount persistent storage model
-- map service directories on that mount predictably
+- maintain a console-only break-glass user baseline with host-scoped recovery password material and a routine reboot exercise on active remote hosts
+- apply predictable persistent storage contracts with explicit mounts for service state, media, and host-critical store paths where required
+- map service directories on those mounts predictably
 - keep provider-specific storage contracts isolated so new hosts do not couple to `oci-melb-1` bootstrap config
+- preserve a documented rescue workflow for storage/mount breakage, including offline rebuild of bootable generations
 
 Track D: Service baseline
 

--- a/hosts/do-admin-1/default.nix
+++ b/hosts/do-admin-1/default.nix
@@ -74,6 +74,14 @@
     sshIntegration = true;
     pamAllowedLoginGroups = [ "shrublab-admins" ];
   };
+  services.hostRecovery = {
+    enable = true;
+    secretFile = ../../secrets/hosts/do-admin-1/system.yaml;
+    rescueUser = {
+      name = "rescue";
+    };
+    reboot.onCalendar = "weekly";
+  };
   services.beszel-agent-auth = {
     enable = true;
     secretFiles.host = ../../secrets/hosts/do-admin-1/system.yaml;

--- a/modules/profiles/base-server.nix
+++ b/modules/profiles/base-server.nix
@@ -3,6 +3,7 @@
   imports = [
     ../core/base.nix
     ./shell-profile.nix
+    ../shared/host-recovery.nix
     ../services/tailscale.nix
     ../services/beszel-agent-auth.nix
     ../services/state-backups.nix

--- a/modules/shared/host-recovery.nix
+++ b/modules/shared/host-recovery.nix
@@ -1,0 +1,149 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.hostRecovery;
+  passwordlessRuleFor = user: {
+    users = [ user ];
+    commands = [
+      {
+        command = "ALL";
+        options = [ "NOPASSWD" ];
+      }
+    ];
+  };
+in
+{
+  options.services.hostRecovery = {
+    enable = lib.mkEnableOption "console-oriented host recovery baseline";
+
+    secretFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Path to the host-scoped SOPS file containing recovery secrets.";
+    };
+
+    secretKeys = {
+      rescuePasswordHash = lib.mkOption {
+        type = lib.types.str;
+        default = "recovery/rescue_password_hash";
+        description = "SOPS key path for the rescue user's password hash.";
+      };
+    };
+
+    rescueUser = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+      };
+
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "rescue";
+      };
+
+      description = lib.mkOption {
+        type = lib.types.str;
+        default = "Break-glass console recovery user";
+      };
+
+      shell = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.bashInteractive;
+      };
+    };
+
+    reboot = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+      };
+
+      onCalendar = lib.mkOption {
+        type = lib.types.str;
+        default = "weekly";
+      };
+
+      randomizedDelaySec = lib.mkOption {
+        type = lib.types.str;
+        default = "1h";
+      };
+
+      persistent = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+      };
+    };
+
+    passwordlessSudoUsers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "dev" ];
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !cfg.rescueUser.enable || cfg.secretFile != null;
+        message = "Set services.hostRecovery.secretFile when rescue user recovery is enabled.";
+      }
+    ];
+
+    sops.secrets = lib.optionalAttrs cfg.rescueUser.enable {
+      host_recovery_rescue_password_hash = {
+        sopsFile = cfg.secretFile;
+        key = cfg.secretKeys.rescuePasswordHash;
+        path = "/run/secrets/host-recovery.rescue_password_hash";
+        neededForUsers = true;
+        owner = "root";
+        group = "root";
+        mode = "0400";
+      };
+    };
+
+    users.users = lib.optionalAttrs cfg.rescueUser.enable {
+      "${cfg.rescueUser.name}" = {
+        isNormalUser = true;
+        description = cfg.rescueUser.description;
+        extraGroups = [ "wheel" ];
+        shell = "${cfg.rescueUser.shell}/bin/bash";
+        hashedPasswordFile = config.sops.secrets.host_recovery_rescue_password_hash.path;
+      };
+    };
+
+    security.sudo = {
+      wheelNeedsPassword = lib.mkForce true;
+      extraRules = map passwordlessRuleFor cfg.passwordlessSudoUsers;
+    };
+
+    services.openssh.extraConfig = lib.mkIf cfg.rescueUser.enable (
+      lib.mkAfter ''
+        Match User ${cfg.rescueUser.name}
+          PasswordAuthentication no
+          KbdInteractiveAuthentication no
+          PubkeyAuthentication no
+      ''
+    );
+
+    systemd.services.host-recovery-reboot = lib.mkIf cfg.reboot.enable {
+      description = "Scheduled host recovery reboot exercise";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.systemd}/bin/systemctl reboot";
+      };
+    };
+
+    systemd.timers.host-recovery-reboot = lib.mkIf cfg.reboot.enable {
+      description = "Scheduled host recovery reboot exercise";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.reboot.onCalendar;
+        RandomizedDelaySec = cfg.reboot.randomizedDelaySec;
+        Persistent = cfg.reboot.persistent;
+      };
+    };
+  };
+}

--- a/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/design.md
+++ b/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/design.md
@@ -1,0 +1,99 @@
+## Context
+
+`do-admin-1` recently lost in-band SSH during a remote networking ownership handoff, and recovery depended on provider console access plus manual rollback. The fleet already has private-first access, Kanidm-backed host auth, and host-scoped secrets, but it does not yet have a declared console break-glass user or a routine reboot exercise that proves remote hosts can come back cleanly.
+
+This change targets both active hosts (`do-admin-1` and `oci-melb-1`) and must preserve the repo's existing operating model: Tailscale-first normal access, narrow host-scoped secrets, and simple host-centric module composition. Because the change adds security-sensitive access paths, the design must keep those paths explicit, host-scoped, and easy to disable or rotate.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a reusable host recovery baseline that can be enabled on active remote hosts.
+- Provide a console break-glass path that is independent from the normal SSH and tailscale login path.
+- Provide a host-scoped rescue user for password-based serial-console administration.
+- Exercise host recoverability on a weekly cadence with a declared reboot timer.
+- Keep recovery secrets and keys narrow, explicit, and auditable through host-scoped secret policy.
+- Define operator workflows for rollout, verification, and rollback.
+
+**Non-Goals:**
+- Rework the normal Kanidm-backed host login model.
+- Introduce public recovery ingress or weaken the Tailscale-first baseline for normal operations.
+- Add initrd SSH, encrypted-root remote unlock, or a full disaster-recovery orchestration system in this change.
+- Guarantee zero-downtime for risky networking changes; the goal is recoverability, not live cutover safety for every change.
+
+## Decisions
+
+### Decision 1: Model recovery as a dedicated shared host module with host-owned inputs
+
+The recovery baseline should live in reusable shared/module wiring rather than ad hoc host-local fragments. Hosts should opt in explicitly and provide only host-owned values such as rescue password material and whether the rescue account is enabled.
+
+**Rationale:** This matches the repo's thin-host/shared-module shape and avoids duplicating sensitive recovery logic across hosts.
+
+**Alternatives considered:**
+- Keep all recovery wiring host-local. Rejected because it duplicates sensitive logic and makes future hosts harder to onboard safely.
+- Put recovery wiring directly into `modules/core/users.nix` only. Rejected because reboot exercise and host recovery policy are broader than user management.
+
+### Decision 2: Defer initrd SSH and focus this change on console-only break-glass access
+
+This change should stop at a console-only rescue path. Provider serial/console access already exists, and the immediate missing capability is a local password-authenticated rescue user when networking or SSH is unavailable. Initrd SSH remains useful, but it should be handled in a later change with provider-specific boot networking validation.
+
+**Rationale:** This closes the actual operational gap now without guessing at host-specific initrd networking behavior.
+
+**Alternatives considered:**
+- Add initrd SSH immediately. Deferred because the host-specific boot networking assumptions are not yet validated and are not the current missing capability.
+- Reuse the normal SSH users for console recovery. Rejected because the problem is specifically the absence of a password-authenticated console path when networking is broken.
+
+### Decision 3: Keep the rescue user separate from Kanidm-backed human access
+
+The rescue user should be an explicit local account intended only for break-glass use at the serial/provider console. It should be console-only, require a password, and use sudo with password. It must not silently become the default human admin path.
+
+**Rationale:** Separation keeps normal identity flows intact and makes the rescue path easy to audit, rotate, or disable.
+
+**Alternatives considered:**
+- Extend the existing `dev` user for break-glass use. Rejected because it mixes routine and exceptional access.
+- Use passwordless sudo for the rescue user. Rejected because the clarified requirement is an intentionally high-friction console-only break-glass path.
+
+### Decision 4: Use an unconditional weekly reboot exercise
+
+The weekly reboot should be implemented as a simple custom systemd timer/service rather than relying on update-triggered reboot helpers.
+
+**Rationale:** The requirement is to exercise recoverability on a routine cadence even when no update is pending.
+
+**Alternatives considered:**
+- Use update-driven reboot features only. Rejected because those do not guarantee a weekly exercise.
+- Omit scheduled reboots and rely on manual testing. Rejected because that lets recovery drift accumulate unnoticed.
+
+### Decision 5: Keep recovery secrets under host-scoped SOPS policy
+
+Recovery password hash material and any related rescue-only secret material should remain under host system/recovery secret scope with no implicit cross-host sharing.
+
+**Rationale:** Recovery paths are high sensitivity and should follow the repo's existing narrow blast-radius model.
+
+**Alternatives considered:**
+- Store rescue password material in shared/common scope. Rejected because it broadens access for a sensitive capability.
+- Manage recovery material outside the repo entirely. Rejected because the baseline needs a declarative audited contract, even if operators also retain out-of-band copies.
+
+## Risks / Trade-offs
+
+- **[Risk] Additional access surface increases security sensitivity** → Mitigation: keep recovery access host-scoped, console-only, and documented as break-glass only.
+- **[Risk] Rescue password handling creates sensitive secret material** → Mitigation: store only password hashes in host-scoped SOPS secrets and document rotation expectations.
+- **[Risk] Weekly reboots can interrupt workloads at bad times** → Mitigation: schedule a narrow maintenance window, keep cadence explicit, and verify services recover automatically afterward.
+- **[Risk] Rescue account drifts into normal usage** → Mitigation: document purpose clearly, keep separate credentials, and avoid coupling it to routine workflows.
+- **[Risk] Recovery rollout can itself cause lockout if misconfigured** → Mitigation: deploy with existing break-glass console access available, validate one host at a time if needed, and keep rollback commands in the operator runbook.
+
+## Migration Plan
+
+1. Add the shared recovery module and host-facing options.
+2. Extend host secret policy and declare host-scoped rescue password material for `do-admin-1` and `oci-melb-1`.
+3. Enable the recovery baseline on both active hosts with explicit host configuration.
+4. Build and verify both host configurations locally.
+5. Roll out using the existing safe remote workflow, keeping provider console access available.
+6. Verify post-deploy recovery baseline: rescue user presence, console login path, weekly reboot timer, and normal service recovery.
+
+Rollback strategy:
+- Disable the host recovery module or host enablement flags and redeploy the previous generation.
+- If remote access degrades, use provider console or the previous verified recovery path to boot a known-good generation.
+- Rotate or remove rescue password material if rollout must be aborted after secret material has been staged.
+
+## Open Questions
+
+- Initrd SSH remains a useful follow-up change once provider-specific boot networking assumptions are confirmed.

--- a/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/proposal.md
+++ b/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Recent `do-admin-1` recovery showed that remote hosts need a stronger declared recovery baseline before risky networking or access changes are attempted. We need a consistent host pattern for serial-console break-glass access and scheduled reboot exercise that improves recoverability without broadening normal SSH posture.
+
+## What Changes
+
+- Add a new `host-recovery` capability covering a declarative serial-console rescue user baseline and routine reboot exercise.
+- Require remote hosts to keep a documented recovery path that does not depend on the primary SSH or tailscale login path remaining healthy.
+- Extend host unix-auth requirements to allow an explicit host-scoped console rescue account that remains separate from normal identity-backed access.
+- Extend secrets requirements so recovery password material remains narrowly host-scoped and auditable.
+- Standardize operations guidance for deploying, testing, and rolling back recovery baseline changes on active hosts.
+
+## Capabilities
+
+### New Capabilities
+- `host-recovery`: Declarative console rescue-user baseline, scheduled reboot exercise, and documented break-glass operator workflow for remote hosts.
+
+### Modified Capabilities
+- `operations`: Deployment and validation workflows must include recovery-baseline rollout, reboot exercise, and rollback checks.
+- `network-access`: Break-glass access expectations must cover console recovery paths that survive primary SSH or tailscale login failure.
+- `host-unix-auth`: Hosts may declare a separate console rescue account with explicit password and sudo policy outside normal Kanidm login flow.
+- `secrets-management`: Recovery password material and related recovery-only credentials must remain host-scoped and auditable.
+
+## Impact
+
+- Affected code will likely include shared host/profile modules, host bootstrap/default wiring, and host-scoped secret declarations for `do-admin-1` and `oci-melb-1`.
+- Affected systems include serial-console access, operator recovery workflows, sudo policy, and reboot timers.
+- This change introduces additional security-sensitive access paths, so host-scoped secret policy and documented validation/rollback steps are part of the baseline.

--- a/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/specs/host-recovery/spec.md
+++ b/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/specs/host-recovery/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Remote hosts SHALL provide a declared recovery baseline
+Remote hosts that opt into the recovery baseline SHALL provide a declared break-glass path that includes a host-scoped console rescue operator path and a routine reboot exercise.
+
+#### Scenario: Recovery baseline is enabled for a host
+- **WHEN** a host enables the recovery capability
+- **THEN** the host configuration declares a separate console rescue operator path and a recurring reboot exercise as part of the host baseline
+
+### Requirement: Console rescue access SHALL be independent from normal host login flow
+Console rescue access SHALL use dedicated host-scoped password material and SHALL remain separate from the normal SSH and identity-backed login path.
+
+#### Scenario: Console rescue configuration is reviewed
+- **WHEN** the host recovery baseline is inspected
+- **THEN** console rescue access uses explicit dedicated host-scoped password material
+- **AND** the normal host login flow does not depend on that rescue access path
+
+### Requirement: Rescue operator access SHALL remain explicit and host-scoped
+The recovery baseline SHALL support a host-scoped rescue operator identity that is console-only, password-authenticated, explicitly declared, and reserved for break-glass administration.
+
+#### Scenario: Rescue operator identity is rendered
+- **WHEN** a host enables rescue operator access
+- **THEN** the rescue identity is declared explicitly for that host
+- **AND** access is available at the provider or serial console without enabling routine SSH login for that account
+
+### Requirement: Recovery readiness SHALL be exercised routinely
+Hosts that enable the recovery baseline SHALL exercise restart recovery on a declared recurring schedule so recovery drift is detected before an emergency.
+
+#### Scenario: Recovery exercise schedule is reviewed
+- **WHEN** host timers and recovery policy are inspected
+- **THEN** a declared recurring reboot exercise exists for the host
+- **AND** the cadence is explicit rather than implicit in unrelated update behavior

--- a/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/specs/host-unix-auth/spec.md
+++ b/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/specs/host-unix-auth/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: SSH and PAM policy SHALL remain explicit and host-safe
+Kanidm-backed SSH and PAM login behavior SHALL be enabled only through explicit host policy, including declarative allowlists for permitted login groups, and hosts MAY declare a separate host-scoped console break-glass rescue account outside the normal identity-backed login flow.
+
+#### Scenario: Host enables sshIntegration
+- **WHEN** a host enables Kanidm SSH integration
+- **THEN** SSH key lookup behavior is declared through `services.kanidm.unix.sshIntegration`
+- **AND** PAM login eligibility is constrained by explicitly declared allowed login groups
+
+#### Scenario: Host enables a rescue account
+- **WHEN** a host declares break-glass rescue-user access
+- **THEN** that account is configured explicitly as a host-scoped exception rather than an implicit fleet-wide normal login path
+- **AND** its console login and sudo posture remains declarative and auditable

--- a/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/specs/network-access/spec.md
+++ b/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/specs/network-access/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Break-glass access remains available
+Network-access design SHALL include documented recovery paths for control-plane failures, including at least one path that does not depend on the primary post-boot operator login flow remaining healthy.
+
+#### Scenario: Tailnet access is degraded
+- **WHEN** primary private access path fails
+- **THEN** break-glass procedures provide alternate operator access
+
+#### Scenario: Console recovery path is needed
+- **WHEN** a host cannot be recovered through the normal post-boot SSH or tailscale login path
+- **THEN** operators have a documented provider or serial console recovery path that can be used outside the normal host login flow
+
+#### Scenario: A remote host adopts declarative network ownership
+- **WHEN** a host is migrated from provider-managed networking to declarative host-owned networking
+- **THEN** the declared stack is self-contained about addresses, routes, and interface ownership
+- **AND** operators do not rely on a live SSH session surviving the ownership handoff

--- a/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/specs/operations/spec.md
+++ b/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/specs/operations/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Deployment flows use canonical repository entrypoints
+Day-2 deployment SHALL be performed through repository-defined operator entrypoints and host flake outputs.
+
+#### Scenario: Host deployment is triggered
+- **WHEN** an operator runs deploy/activate workflows
+- **THEN** deployment targets declared host outputs and follows repository command contracts
+
+#### Scenario: A deployment changes network ownership on a remote host
+- **WHEN** activation would stop the currently active network stack or otherwise cut the in-band SSH transport
+- **THEN** operators use a boot-time deploy workflow that updates the next generation without live-switching the running network stack
+- **AND** the host reboot is performed with break-glass console access available
+
+#### Scenario: A recovery baseline change is rolled out to a remote host
+- **WHEN** operators deploy changes that affect rescue-user access or scheduled reboot behavior
+- **THEN** the rollout includes an explicit verification step for the new recovery path
+- **AND** rollback or prior-generation access remains available until verification completes
+
+### Requirement: Break-glass baseline and rollback paths are documented
+Operators SHALL capture baseline state before risky changes and SHALL have documented rollback/recovery procedures.
+
+#### Scenario: Recovery is required
+- **WHEN** SSH/Tailscale access degrades after change
+- **THEN** break-glass steps and generation rollback commands are available to restore access
+
+#### Scenario: Recovery baseline is audited
+- **WHEN** operators review host recovery readiness for a remote host
+- **THEN** the documented runbook includes how to verify console rescue access, rescue-user access, scheduled reboot cadence, and rollback steps

--- a/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/specs/secrets-management/spec.md
+++ b/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/specs/secrets-management/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Host exception secret scopes SHALL stay narrow and explicit
+Host exception secret scopes SHALL be reserved for host/bootstrap/system-only material, host recovery material, and explicitly declared cross-host identity handshakes, and SHALL NOT become a fallback bucket for general application internals.
+
+#### Scenario: Host system secrets are reviewed
+- **WHEN** `secrets/hosts/<host>/system.yaml` is inspected
+- **THEN** it contains host/bootstrap/system-only material
+- **AND** reusable application/service internals are absent from that scope
+
+#### Scenario: Host recovery secrets are reviewed
+- **WHEN** host-scoped recovery key material is inspected
+- **THEN** rescue-only password hash material or equivalent recovery secrets remain limited to the target host scope
+- **AND** unrelated hosts do not gain decryption access implicitly
+
+#### Scenario: Cross-host identity handshake material is reviewed
+- **WHEN** an explicit host-exception identity scope such as `secrets/hosts/<host>/oidc.yaml` is inspected
+- **THEN** its reader set matches the declared host-identity handshake need
+- **AND** it does not implicitly grant access to unrelated application/service secret material
+
+#### Scenario: OIDC client credentials are consumed after Kanidm migration
+- **WHEN** a composed admin or standalone service consumes OIDC client credentials for Kanidm provisioning or runtime auth
+- **THEN** those client credentials continue to come from explicit scoped secret files through the leaf module's secret contract or helper-rendered runtime file path
+- **AND** application composition only passes the required contract inputs or resolved env-file paths without taking ownership of the underlying secret registration

--- a/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/tasks.md
+++ b/openspec/changes/archive/2026-05-06-add-host-recovery-baseline/tasks.md
@@ -1,0 +1,17 @@
+## 1. Shared recovery baseline
+
+- [x] 1.1 Add a reusable host recovery module and shared options for console-only rescue-user enablement and scheduled reboot cadence.
+- [x] 1.2 Wire the shared recovery baseline into the appropriate shared profile or host composition entrypoint without changing unrelated host behavior.
+
+## 2. Host and secret wiring
+
+- [x] 2.1 Extend host-scoped secret policy and secret declarations for `do-admin-1` recovery material.
+- [x] 2.2 Extend host-scoped secret policy and secret declarations for `oci-melb-1` recovery material.
+- [x] 2.3 Enable and configure the recovery baseline on both active hosts with explicit host-owned values.
+- [x] 2.4 Add the break-glass rescue user wiring and declarative console-login/sudo policy for hosts that enable the baseline.
+
+## 3. Validation and rollout guidance
+
+- [x] 3.1 Build and validate `do-admin-1` and `oci-melb-1` recovery-enabled configurations locally.
+- [x] 3.2 Update operator docs/runbooks for recovery verification, weekly reboot expectations, and rollback steps.
+- [x] 3.3 Validate the OpenSpec change and confirm the change is ready for apply.

--- a/openspec/specs/host-recovery/spec.md
+++ b/openspec/specs/host-recovery/spec.md
@@ -1,0 +1,36 @@
+# host-recovery Specification
+
+## Purpose
+TBD - created by archiving change add-host-recovery-baseline. Update Purpose after archive.
+## Requirements
+### Requirement: Remote hosts SHALL provide a declared recovery baseline
+Remote hosts that opt into the recovery baseline SHALL provide a declared break-glass path that includes a host-scoped console rescue operator path and a routine reboot exercise.
+
+#### Scenario: Recovery baseline is enabled for a host
+- **WHEN** a host enables the recovery capability
+- **THEN** the host configuration declares a separate console rescue operator path and a recurring reboot exercise as part of the host baseline
+
+### Requirement: Console rescue access SHALL be independent from normal host login flow
+Console rescue access SHALL use dedicated host-scoped password material and SHALL remain separate from the normal SSH and identity-backed login path.
+
+#### Scenario: Console rescue configuration is reviewed
+- **WHEN** the host recovery baseline is inspected
+- **THEN** console rescue access uses explicit dedicated host-scoped password material
+- **AND** the normal host login flow does not depend on that rescue access path
+
+### Requirement: Rescue operator access SHALL remain explicit and host-scoped
+The recovery baseline SHALL support a host-scoped rescue operator identity that is console-only, password-authenticated, explicitly declared, and reserved for break-glass administration.
+
+#### Scenario: Rescue operator identity is rendered
+- **WHEN** a host enables rescue operator access
+- **THEN** the rescue identity is declared explicitly for that host
+- **AND** access is available at the provider or serial console without enabling routine SSH login for that account
+
+### Requirement: Recovery readiness SHALL be exercised routinely
+Hosts that enable the recovery baseline SHALL exercise restart recovery on a declared recurring schedule so recovery drift is detected before an emergency.
+
+#### Scenario: Recovery exercise schedule is reviewed
+- **WHEN** host timers and recovery policy are inspected
+- **THEN** a declared recurring reboot exercise exists for the host
+- **AND** the cadence is explicit rather than implicit in unrelated update behavior
+

--- a/openspec/specs/host-unix-auth/spec.md
+++ b/openspec/specs/host-unix-auth/spec.md
@@ -12,10 +12,15 @@ Fleet hosts SHALL support Kanidm client and unixd integration through native nix
 - **AND** the host consumes the canonical Kanidm server URI rather than a duplicated local literal
 
 ### Requirement: SSH and PAM policy SHALL remain explicit and host-safe
-Kanidm-backed SSH and PAM login behavior SHALL be enabled only through explicit host policy, including declarative allowlists for permitted login groups.
+Kanidm-backed SSH and PAM login behavior SHALL be enabled only through explicit host policy, including declarative allowlists for permitted login groups, and hosts MAY declare a separate host-scoped console break-glass rescue account outside the normal identity-backed login flow.
 
 #### Scenario: Host enables sshIntegration
 - **WHEN** a host enables Kanidm SSH integration
 - **THEN** SSH key lookup behavior is declared through `services.kanidm.unix.sshIntegration`
 - **AND** PAM login eligibility is constrained by explicitly declared allowed login groups
+
+#### Scenario: Host enables a rescue account
+- **WHEN** a host declares break-glass rescue-user access
+- **THEN** that account is configured explicitly as a host-scoped exception rather than an implicit fleet-wide normal login path
+- **AND** its console login and sudo posture remains declarative and auditable
 

--- a/openspec/specs/network-access/spec.md
+++ b/openspec/specs/network-access/spec.md
@@ -38,11 +38,15 @@ Firewall policy SHALL enforce explicit trust boundaries for allowed interfaces a
 - **THEN** only ingress-required ports are opened and private-service ports remain non-public
 
 ### Requirement: Break-glass access remains available
-Network-access design SHALL include documented recovery paths for control-plane failures.
+Network-access design SHALL include documented recovery paths for control-plane failures, including at least one path that does not depend on the primary post-boot operator login flow remaining healthy.
 
 #### Scenario: Tailnet access is degraded
 - **WHEN** primary private access path fails
 - **THEN** break-glass procedures provide alternate operator access
+
+#### Scenario: Console recovery path is needed
+- **WHEN** a host cannot be recovered through the normal post-boot SSH or tailscale login path
+- **THEN** operators have a documented provider or serial console recovery path that can be used outside the normal host login flow
 
 #### Scenario: A remote host adopts declarative network ownership
 - **WHEN** a host is migrated from provider-managed networking to declarative host-owned networking
@@ -68,3 +72,4 @@ Cloudflare resource declarations SHALL be owned in control-plane artifacts, whil
 #### Scenario: Runtime change depends on Cloudflare policy
 - **WHEN** runtime/Nix change needs edge policy values
 - **THEN** values are consumed from canonical policy and generated outputs rather than duplicated unmanaged config
+

--- a/openspec/specs/operations/spec.md
+++ b/openspec/specs/operations/spec.md
@@ -3,67 +3,96 @@
 ## Purpose
 
 Define the canonical operator workflows and command contracts for verification, deployment, observability, and break-glass recovery.
+
 ## Requirements
+
 ### Requirement: Contract verification gates operations
+
 Phase contract checks SHALL exist and SHALL be used to detect configuration drift before deployment, including drift between public edge exposure policy and private-origin upstream policy.
 
 #### Scenario: Ingress policy drift is introduced
+
 - **WHEN** route exposure mode or domain mapping diverges from declared edge policy
 - **THEN** verification fails prior to deployment
 
 ### Requirement: Deployment flows use canonical repository entrypoints
+
 Day-2 deployment SHALL be performed through repository-defined operator entrypoints and host flake outputs.
 
 #### Scenario: Host deployment is triggered
+
 - **WHEN** an operator runs deploy/activate workflows
 - **THEN** deployment targets declared host outputs and follows repository command contracts
 
 #### Scenario: A deployment changes network ownership on a remote host
+
 - **WHEN** activation would stop the currently active network stack or otherwise cut the in-band SSH transport
 - **THEN** operators use a boot-time deploy workflow that updates the next generation without live-switching the running network stack
 - **AND** the host reboot is performed with break-glass console access available
 
+#### Scenario: A recovery baseline change is rolled out to a remote host
+
+- **WHEN** operators deploy changes that affect rescue-user access or scheduled reboot behavior
+- **THEN** the rollout includes an explicit verification step for the new recovery path
+- **AND** rollback or prior-generation access remains available until verification completes
+
 ### Requirement: Operational status commands are available
+
 The operator surface SHALL provide commands for host status, service logs, and ingress health checks that distinguish public edge reachability from private-origin upstream behavior.
 
 #### Scenario: Ingress health is checked
+
 - **WHEN** edge proxy changes are deployed
 - **THEN** operators can verify Caddy edge status, certificate state, and effective route behavior for edge and upstream transport
 
 ### Requirement: Break-glass baseline and rollback paths are documented
+
 Operators SHALL capture baseline state before risky changes and SHALL have documented rollback and recovery procedures, including offline rescue rebuilds for storage-related failures.
 
 #### Scenario: Recovery is required
-- **WHEN** SSH, Tailscale, or boot viability degrades after a storage or mount change
+
+- **WHEN** SSH/Tailscale access degrades after change
 - **THEN** break-glass steps and generation rollback commands are available to restore access
 - **AND** the workflow includes offline rescue rebuild guidance for restoring `/nix`, mounting the ESP, and reinstalling a bootable generation when live recovery is no longer possible
 
+#### Scenario: Recovery baseline is audited
+
+- **WHEN** operators review host recovery readiness for a remote host
+- **THEN** the documented runbook includes how to verify console rescue access, rescue-user access, scheduled reboot cadence, and rollback steps
+
 ### Requirement: Host recipient management is operationalized
+
 Host key to age-recipient derivation SHALL be available via operator workflows with preview and update modes.
 
 #### Scenario: A new host recipient is added
+
 - **WHEN** operator derives host recipient material
 - **THEN** recipient generation and optional policy update are performed via documented commands
 
 ### Requirement: Build/check workflows validate repo integrity
+
 The operator surface SHALL include flake validation and host build checks.
 
 #### Scenario: Pre-deploy validation runs
+
 - **WHEN** operators run check/build commands
 - **THEN** flake outputs and host build artifacts are validated prior to apply
 
 ### Requirement: Backup and restore workflows SHALL be documented as canonical operator runbooks
+
 Operations documentation SHALL include canonical workflows for backup initialization, on-demand execution, recurring verification, restore preparation, and post-restore validation for host-scoped state backups.
 
 #### Scenario: Operator prepares or audits backup operations
+
 - **WHEN** an operator reviews the repository runbook surface for backups
 - **THEN** the steps for initializing repositories, triggering backups, checking repository health, and validating restores are documented
 - **AND** the runbook distinguishes routine backup execution from break-glass recovery flows
 
 ### Requirement: Backup validation SHALL include restore-oriented checks
+
 The operator contract SHALL require validation beyond successful backup completion, including at least documented or executable checks that confirm critical backups are restorable.
 
 #### Scenario: Backup validation is performed for a critical service
+
 - **WHEN** operators validate backup health for identity or SQLite-backed services
 - **THEN** validation includes restore-oriented verification steps rather than only timer/job success status
-

--- a/openspec/specs/secrets-management/spec.md
+++ b/openspec/specs/secrets-management/spec.md
@@ -134,12 +134,17 @@ When Karakeep secret/template ownership is leaf-managed, runtime containers SHAL
 - **AND** Karakeep runtime receives required secret-backed variables (including NextAuth and OIDC client credentials when OIDC is enabled)
 
 ### Requirement: Host exception secret scopes SHALL stay narrow and explicit
-Host exception secret scopes SHALL be reserved for host/bootstrap/system-only material and explicitly declared cross-host identity handshakes, and SHALL NOT become a fallback bucket for general application internals.
+Host exception secret scopes SHALL be reserved for host/bootstrap/system-only material, host recovery material, and explicitly declared cross-host identity handshakes, and SHALL NOT become a fallback bucket for general application internals.
 
 #### Scenario: Host system secrets are reviewed
 - **WHEN** `secrets/hosts/<host>/system.yaml` is inspected
 - **THEN** it contains host/bootstrap/system-only material
 - **AND** reusable application/service internals are absent from that scope
+
+#### Scenario: Host recovery secrets are reviewed
+- **WHEN** host-scoped recovery key material is inspected
+- **THEN** rescue-only password hash material or equivalent recovery secrets remain limited to the target host scope
+- **AND** unrelated hosts do not gain decryption access implicitly
 
 #### Scenario: Cross-host identity handshake material is reviewed
 - **WHEN** an explicit host-exception identity scope such as `secrets/hosts/<host>/oidc.yaml` is inspected

--- a/secrets/.templates/hosts/system.yaml
+++ b/secrets/.templates/hosts/system.yaml
@@ -5,6 +5,12 @@
 tailscale:
   auth_key: <value>
 
+recovery:
+  # Console-only break-glass password hash for services.hostRecovery.
+  # Generate a SHA-512 crypt hash, not a plaintext password.
+  # Example: mkpasswd -m sha-512
+  rescue_password_hash: <sha512-crypt-hash>
+
 backup:
   # Host-scoped backup credentials for services.state-backups.
   # These map to defaults in modules/services/state-backups.nix:

--- a/secrets/hosts/do-admin-1/system.yaml
+++ b/secrets/hosts/do-admin-1/system.yaml
@@ -1,35 +1,38 @@
 tailscale:
-    auth_key: ENC[AES256_GCM,data:D0Q56wZGjMHifvOMS84b/oRkNX37PUGO81UWyUk3YqyiedswWg1PqcY5KPolILTiL0GwuSJ5bgaDek5JF+0=,iv:ICjwIIzpzoMeb3pnEh/9K5zllI6MRVcTFRIBHbu2QQA=,tag:36mIP/TWtb1It3f2fL6+1w==,type:str]
+    auth_key: ENC[AES256_GCM,data:32Z8zyx7EeU7sOCanlP0X5ir92TgvkDtMwgT4ofoBiMTMfGlD6UQIEBn2kgA2vXZIHPP+YF/7SN0YMAVDV4=,iv:Cfb+yA8tW/U4d6I3zOvNMJDdvKO7dhGVWwEJbpfhfg0=,tag:4+rBAClWaVBedVWHn7H71w==,type:str]
 beszel:
-    token: ENC[AES256_GCM,data:sVhKxQhEHzefk3hmauJ35U5bkh53dvtXzMHlEOho/nsStXNd,iv:oATf8/3EyR4HGxl69zAKj+1nKD/itL7cuHmhcCT078w=,tag:DLKuOmDjWEspGYNmmGzBPQ==,type:str]
+    token: ENC[AES256_GCM,data:RPx0xfXG6cZK2XY5RrgddDFO/ZVp0UFuPKC1biy0tWl0A1aC,iv:ksBMrUE3LZL9ipeYkJ0dItGXQ4HOvnAfyXRnvKYW7Us=,tag:678gm9Ha0LjDsFwt2cqBcQ==,type:str]
 cockpit:
     service_user:
-        password_hash: ENC[AES256_GCM,data:Nf0sylNjHKz3PeZPjZBx6p+viqnL3YF+LP9O8UJLcWPFku6aLgy9msghrOtgkrHamCV6V5Wla9lMPzAx2ytYy8IAmmYLQD3Siw==,iv:ipiJ2zkw/bAVWdoxloKjWUL7Sodl9G89Ve18bNKZ9+I=,tag:196kW+nNnE+o5deth8PkkA==,type:str]
+        password_hash: ENC[AES256_GCM,data:A76G7HB1y8JWHoAVShEXzVTRud4/Ce1PPxGdLDWF1oIm3/fXZhgGrKX/yX43T4kVAEkx7MOQGqMYANUrEu0ObqsZiwthGay3Ig==,iv:oHQXj/Nr7BxuRNyny64IRG9inZtg1U7emD5C8o3VfYA=,tag:xEZwqrUUEWaJ2mk/WjU7kQ==,type:str]
 backup:
-    s3_access_key_id: ENC[AES256_GCM,data:23QvHiZjjQ7oYBbhiQxVYIaW4zJbDYOyujYUrfZux8M=,iv:ecdKUx6p4jTik3PZVLuR8VrTUpdf4TUkz1ojsm+2MUo=,tag:IDMJDBaA0I5IJi21RYA8EA==,type:str]
-    s3_secret_access_key: ENC[AES256_GCM,data:7t7x6pb7DIRqEPJBoky/gx6tWYSfb+rXV09zAHeO3MOrKRZZpw2NAlXozF9g4bSgY4S73qjjDntaWLAk4QzCEg==,iv:SlqEajohD5hSixnBAoAyCyGhGrY8Inv3tiv4O5Gpu+M=,tag:Fo8VJqUxyoy1LpKPB4MB8g==,type:str]
-    restic_password: ENC[AES256_GCM,data:IJxYdfoqXN1XzdNjG5PeuH4dEznpVzJ0Urs8R/dZOsrbxOX4KIG3ZbYB75A=,iv:2RmnQI6o3JApM2oMf+X7egWxdBrclVkxxwV5nPe79pI=,tag:tgZFpWYxm5nix1m5ncOJTg==,type:str]
+    s3_access_key_id: ENC[AES256_GCM,data:FeRpT5LnEKZXWZDz28byiCUxP4kYNjVICUNokUdl2cU=,iv:eaUos0RutFc5Sq21S1RkR6OEel62MiJH7uZpVlmHRrI=,tag:qNPYIbK6YWg2UXCkFPlXBA==,type:str]
+    s3_secret_access_key: ENC[AES256_GCM,data:lG72bKa9gNSFZ4YC3r8ODWoswpp6vdIfHER3WD+T30n4ES31wRlQo8ZcY9d/xVNjWcpjWsKlBmLbjTeBr1Iq3w==,iv:cPRldFyyVwPiFOOg53qFh1Ev6/XekaGeATZlAjQyxi0=,tag:PBSTkuC2W+q/yfzEEYiLgw==,type:str]
+    restic_password: ENC[AES256_GCM,data:sL2+KiJCGw8H5Yh709csClGBrJquimYLifZWFST6Ob5p8HDEcHyGc5fXXCg=,iv:xhwSflppG8OT849MCCmUAH3zKvNItsM8oIjYtQ9fSy0=,tag:UPFSpSfnb4DTW5nws8J1qA==,type:str]
+recovery:
+    rescue_password_hash: ENC[AES256_GCM,data:sU90YZgJARPs3ls29BqmffywChlYl1wvo31xB5vKVHehZHmhv8HsyR9D8fe1hIBDoYMpVXXkWN9kKKkczyFKGldWox8flFYjwJeu3uODjy2ZiFRgcavhWXcODMWmxtUgTByysgNp+fz9Og==,iv:owoASTGahJ+JQjhGCdbSavJMFBLIfM47WG1ZUMJ86LI=,tag:mZtE6qNl8AM1brODHbIBMw==,type:str]
 sops:
     age:
         - recipient: age1w5asfm5rfncy4yvslj3az78kvn7hkrzq4vy0mzexf36w64a7e3nqamw3fp
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtVXBpdUw3Y05mbUt3TTBl
-            Y0lmS2ZBOFg5c21sRFFMRGR5VE5VWTVjdlJrCjYyQngxSElkWmVaQnNKRFlKYlIy
-            VUU4Y1NUZGZ0dE44ZEg1VEVkNitQOUUKLS0tIERTdWJVTUZaR09WU2VQeE1ZV09G
-            b3lTcmVXRVFZTUdjV2kzSkdrMW5rTXcKrsDx0K02NPDkUMM/HdvnLXzdbqXTpDCL
-            T5/ti97cRgex6cCWy1uavE9o9KO3G8ACqdSh6/zIQNDqHFC2EIQB3A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJMWF2bWlCL0I5U25IM2p0
+            VHpIRTZrOEtDNUZXTkl1OEQ2RHBqTWgxNEYwCmFvUnZxTi9vOElnQ292RnJMMldK
+            NlhqQmdrL3JDTEpQRzA2UlArRks3dEEKLS0tIExJb3JNSFB1a0pkTjBzdjZlS05s
+            ZmFmZXZoSC9OTkQ0d29xb2c5S1BaRm8KObWRIDzjVl9leNSbvNjfVfynZc94GhxR
+            z+QW0KyWAsz8rVAwWcArChRVle699QgNuCldjEasqi+yptYuA5QZ5A==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1a2masnj7tmwjl9azt75kh387lvwwz9vqfhqr0emghdcvu7x9jd9q4wv4aq
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEM2xjNHBtVjgxMDBYTWc3
-            UGgvM2ZCUVJ6akVOQlVEMWNsS29uUmZhaDNjCmZQdjNpcW9sNW53dDUxalhvb0s5
-            VTZ2eTZwdWs2NUd4MWxvZnhCRGpXL1UKLS0tIHErZDdQWWtxS1BxdmlXbkl2cnR6
-            dTA1R1lHeDNYSHY1K3hBM2JVVWh1RDgKx44hBysellCQw+WfV2cic4ohtbyqike4
-            y45phgAGGWu6WJAQo8DRjFt4e5wopDBKJcEClxCF2HIK2DtcCJmNug==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkZUdMR2x2dHlCRHE1WVdJ
+            ZFhFUmt5Y21rY0JxV1QxemRCamE1bjdOZWswClJPQ3RuUFB5NG1odHRKWkhkb0lD
+            WGdvdEducVJ2a0s5b2FvbzdXeFlPMkEKLS0tIHNrWHl3ZlI2UEowR1VaNUxkMk1X
+            dllLSTNubXFUTzB6NWJOdDBWMjRSc0EKPj3ixXh+fRAzw8TKoCKCoyFPOYGmD795
+            JgzpWp13K34olJKr03E6K5IIoQt7MlevFrWyBcpTjyu4NxnWaQgztQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-05T17:29:38Z"
-    mac: ENC[AES256_GCM,data:ZgyA9CbdAcUHUUswpjGqaIzPBB0GDQ+dj8DAFvuBFIjOzoGaBXZdTpQK9FIVrqDLEVuNN2jDQ8PqmrNQby8lx4+jnLGFY2mHYgefm2RBcL7oFLIjA5g/vlCHsCnnxI89OTP/wvIJNAppCGdHuarwAFT7mpV57Wpx6zlVYwotgFQ=,iv:jEV//4hB6qE0CKBAIYOqK0DTOeX0SQsUSEhZoVK0pFs=,tag:swXsVYxjX4qGGvkkPvRIrA==,type:str]
+    lastmodified: "2026-05-06T10:09:35Z"
+    mac: ENC[AES256_GCM,data:Swu7gchYfilTB7fmWQR2pjbNA6upgDKFjsoA7Mu1DMCthVVouTgcVQnxYEV3GLOFVCSW4m3fPmBLzOIuWyOAyTXTdp4Fb5dRAc0ZMFhHUqsTmDe5PnrLv1Js+w9tMRuA7ew9PNhFu8HcNB8PMCanNf2qVOTkE4E3OwzxSEPIkxA=,iv:a2b9j0z+5Pz53uRGMrr8W+RhC6qrsHkUUlZMlCAtZls=,tag:wJ54zRBbiENtZ1Q9155EZA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2
+

--- a/secrets/hosts/oci-melb-1/system.yaml
+++ b/secrets/hosts/oci-melb-1/system.yaml
@@ -1,36 +1,38 @@
 tailscale:
-    auth_key: ENC[AES256_GCM,data:+s2n9YXtpWeEf6I9q25p1G2bPu7do25vtTVCmcTwLWJRi2cjUsRP1GQiQD0O9EXUQBaQvQy82diJ/eaF0Oo=,iv:Yak94+pgogWnpx/563Wve7zMHFh3LGe4AFZ6iu0SqbA=,tag:vZOSV9wm6M0A3pzfSQLPAw==,type:str]
+    auth_key: ENC[AES256_GCM,data:DNH4/q8FTfGzs+O3CoHaidm6qC8Y+BmtET3qL8tjzUINyD1NQls0/4GOfiIBOl3+VMS7BB4EUJaUtYX5LJU=,iv:7Lvw77QE/MHJgv5/pRl5L01AwMcQfR4PUK24cXuuYFE=,tag:hc6QsJPaLbk6121ntcHUUA==,type:str]
 beszel:
-    token: ENC[AES256_GCM,data:8PLkkDryMyZqITKJiYswNTiBOlgq6hCN+/rscjlTTAtJiMEU,iv:Y07k54jFAhVYypEzg0Wf6f+SSERTsDNEwJGtouzlW90=,tag:VbISbEwOv47IFW0MGyeOCA==,type:str]
+    token: ENC[AES256_GCM,data:0oWNCZ3aArhqNb5eLT5PQU2B0f0I01d5a/sJuCyf0c4hVmCR,iv:Sydq5BAXpq3FvWklO2tFB9z7k6BAMi4CoYb2/gX1hyE=,tag:IrQI8NVXqY7mZoJ+D1UWAQ==,type:str]
 cockpit:
     service_user:
-        password_hash: ENC[AES256_GCM,data:IerAENlCfWhyLkN1YyNhrH+YoOkgBUkj92vk/+CWEMIZLeWd/dmA38fZEllouIuEl/86V7/SZCWZ27rUITQ0ANovdBjVmdfNlg==,iv:CD/1Ba084fULP0lTcpp/fNXN4sr582+CW3H31/pocGI=,tag:0J17/0EfmMBvqSiva+jxXA==,type:str]
+        password_hash: ENC[AES256_GCM,data:2046IEZ6AfdoWdRfuS77KFECwUxUzqqFUFl/0+bwqfZGxA+xtENcGhB67GSM0dU+Shz1TDpuja1bZDKtX6UzuZ70755wzvkpLQ==,iv:L6Vym78OrG4YD/nx5knHFCUUo9FSg5ElrPcevyaSKzc=,tag:/at2RI3sK+zTzTE+62Uelw==,type:str]
 backup:
-    s3_access_key_id: ENC[AES256_GCM,data:caNk2ZX1DT8TImSw6euEkON0ROMhKeuUTTk0j9Uw+/k=,iv:b4bEg7q2hzZCNPhWEjQGstBGRjiND3REjuNvXtR/hLM=,tag:UczzAcdPfAFKpFKIrOTePw==,type:str]
-    s3_secret_access_key: ENC[AES256_GCM,data:cGJGTGYCAjg7u4oxf6k57GBoQleq5MkNJMsaFZfoUHd7NACWGgs0SYhQFTjtJxnmNFEGcdZDSFz0HkcSBVf8WA==,iv:EX4cDbF96ZTTXLDyGj0AVgUFCpW7icrQpAI5jLlxKTM=,tag:7DVjToiGtNUxMHb9v13eag==,type:str]
-    restic_password: ENC[AES256_GCM,data:uv4cfc8V1/UnvjckFMl200s89h8u1W5TI2yhwkL0Q3FHtHAunio0ZEUQjTM=,iv:9S0+YoEW5egdomPnHIv1WihTKnj8aqlPWOVQlOuXE9s=,tag:PMcepE2OkgZzG4JIgIKaIA==,type:str]
+    s3_access_key_id: ENC[AES256_GCM,data:jXOTpIpwIKT01eJmAF2xP0ad8qgwbPgJ+Y+JWcGHZms=,iv:pBYMFfGryeq3pdb//WmaLy0b2aFXg1vXH7ZO2yX/9T0=,tag:8lm5nryE+wjGVjq9gFX9eA==,type:str]
+    s3_secret_access_key: ENC[AES256_GCM,data:l23q+EjwKz4RbAhtyF8fDD4W2AiH1VpTXOGjGT3CNZK4HQ7k+dAzMaJx1lJDrxd+iG0Mdu/VnwRE9qsT/xoAnQ==,iv:x1vaC/ucWgC8NqgHoqgcatI786D8kDUU/WOZqvHx3Qg=,tag:IDG9Ersg2BdTHYcYLRUVgg==,type:str]
+    restic_password: ENC[AES256_GCM,data:QOv9CSM9Y6M0SUgCKrbCt+bfSZA+JQEJHeEKoOvAOj/zXB7iNQtcsIN1Rk0=,iv:BumbThKqbwE0OanF3074h4f0EBeO0QUe0HxynV6p9RM=,tag:RwnZpKioTCReSXDDa3h8tA==,type:str]
+recovery:
+    rescue_password_hash: ENC[AES256_GCM,data:WDhfWgp8dtsjGKfB+4dqHi0YXKXZdSQvwdyhQzaI1/apWnCtTrXrh7L4dSPptvz6GxQTAHJWyD1096EIbMQdJrqmnBAbxoQpQIDCMR7140tySP1jKEnAcVgfPk4FMnKrBMhELzA8UAE7zQ==,iv:Zwg5s4T45qj6RVHlSbopQwDMu6Qht39YbJKSnhTOF9w=,tag:4pfQxtzHOP2oLeckHdT1zg==,type:str]
 sops:
     age:
         - recipient: age1w5asfm5rfncy4yvslj3az78kvn7hkrzq4vy0mzexf36w64a7e3nqamw3fp
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2YWZBQ0dycTU2VkNDSHEv
-            Wng3MndwY2lzSXhPQ0pGZFNNME82QzRQOEVNCjBXbDZsZHJmcTM2ZDM5cEVUYTlR
-            QzlKT0pxQ3lGUzl2dmRJVm1zK0NlOE0KLS0tIEhaUUh6UzVDS1hOTkJScjRwZEJu
-            Zk1FTnpNU0hodENnQ1cxRnJKZzZMbDAKxToXUFOhTcrM91WBlnrZKT3hu71ran2z
-            BvGcv/Wjfg6aqVlVo7tfT4JIk07ZYrLp/UD0NG+wwRLpWeoDCfv62g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsTEh2a052K3dCeHpmekhX
+            NG0vVWVsVHJRTGd4bk9INzlVUzhsOEVpRDN3CjJoMnRRNWxaUXZZZzVRZDZnY285
+            VmQxQlpFckh6cVVHUjJ6T3BHNEEvaDQKLS0tIFFFVlh6a1E2anV5QWIyNm54ZlJs
+            azZsMTlmYnJtOVNwRHgySVNmZk4wUzAKmnFiKMxfshsiWcAxLSWkCHb7fiuKX8MR
+            5l3mv9wmWGS9DxgCE7zHaB6+raYO9xwCxfC5zOu91gX/Cmj497XYug==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1lg45rhdn6mp856f97sdwxu7rpzyyz7edqwnldnpj67r6curnkqws7nn42a
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvd0ZBZ09pZFdvQ3ZsVmZn
-            Ym1WYU8yd3pmK0lMR1N2R2xhQVd6UkwzMWxnClJ2NTE4TFFpNlhlRGI2aWtuaHhV
-            dXk4VTJoRk9sU3FQMDZHQmlQckNvUEkKLS0tIE1PRzB3WVdxSXlocmFGSTEySEtI
-            cURxam1xbDNMYjcyMGJDWnR1T3J0RFEKvuaBUzjfSXSXZEgLsNw0R+GNgQ99WLsg
-            AJfM+a+/CB35Y156TyhhLhNNZ6iZfZ7HyPkMCqj5THDqx8oxn+F4UA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVS3R5S2xidHVVV2dXWllR
+            Z09YTW1BWG5wSzhSN1pVYjB1S0g2ZzZZcmpjClpheXFTQXpsSDZMQ25Kc3I1UEEr
+            UnF6ZHU1bFI0VjM1elRJRkNMT3g5cUEKLS0tIE5QMkhteHUvUXc5bjZIY1crekpy
+            SU1waDlVdVU5ZmdhWFpoamNiYTVwSUkKavgNr6S4w8J4smGlmXMJUnlLcN0UcQus
+            BJrIazqZ73m/UBiDmmROVPFX+rAFvB/3oYr0nFyIOzfBP8SRO8NMYw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-05T17:31:31Z"
-    mac: ENC[AES256_GCM,data:c0VRMzBe7uDNLcjXgllz0q3qxzSeGA40NfPQIU/u5sJfSxiUwkyLQ3eSMGnptSvVtWd3Mv3X2FDYiQ2lIRwYRqXbNxSZ+uUoQLPn8OkgGteLKxskKJiHFYDYLaF6O6zlT7ht+w92hIaPGbTU96OGf7tBpB/e/7XvpDunivoSTAk=,iv:khErGqdFCkhqCy/hVsscKD8etCsp5VppgI9QK40bN9k=,tag:l+HJ6k83Ww2OgmOXUPyl+g==,type:str]
+    lastmodified: "2026-05-06T10:09:47Z"
+    mac: ENC[AES256_GCM,data:IDzovF60AAQ17ED9kv1x/PUlpl+RQjyiyB1UY/lfcjLHeXtMIFJJANpb0zLjj+s29sPTq83SNIsU56xu1wfkRS31zow/IQj5vKsgZj0nXBrYQmmFwJWeElgAa0PeG9fZVL7rT4ym1HcMCKdbUUIhk/bknhQ9r1JPiPgFkVorkmM=,iv:i4mfOEkkTn04O7wWwVUnlZOW43PCf10XDppuzYsmu+8=,tag:atJrl8ncoqfrHJU5vauURg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2
 


### PR DESCRIPTION
This pull request introduces a new, feature-owned host recovery baseline for remote hosts, centered around a console-only `rescue` user with password-based local login, routine reboot exercises, and improved recovery documentation and architecture. The changes ensure that recovery secrets are managed declaratively, recovery readiness is routinely exercised, and the rescue path is separated from normal admin flows. Documentation has been updated throughout to reflect the new recovery model, storage layout, and operational lessons learned.

**Host Recovery Baseline Implementation**

* Added the new `modules/shared/host-recovery.nix` module, which provides a configurable, feature-owned host recovery baseline. This includes a console-only `rescue` user, password hash management via SOPS, and a scheduled weekly reboot timer to exercise the recovery path. The rescue user is denied SSH access and requires a password for sudo.
* Enabled the host recovery feature for `do-admin-1` in `hosts/do-admin-1/default.nix`, specifying the host-scoped secret file, rescue user, and reboot schedule.
* Ensured the base server profile imports the shared host recovery module, making the recovery baseline available to all hosts using this profile.

**Secrets and Storage Model Updates**

* Updated `.sops.yaml` to clarify that host exception scopes now include recovery password hashes, ensuring correct secret management for recovery users.
* Documentation and decision records (`docs/architecture.md`, `docs/decisions.md`, `docs/plan.md`) now capture the new storage layout for `oci-melb-1` (dedicated `/nix` filesystem, labeled filesystems for `/`, `/srv/data`, `/srv/media`), and the canonical ownership of shared media roots by the music application module. [[1]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782R178-R193) [[2]](diffhunk://#diff-e9132f4093ec8f992b1c832ca2f6f40340fd2e2e632a21218da92a3d457e6088R115-R143) [[3]](diffhunk://#diff-522bf533200e1c7005156fe6bfcdedcbbb3dd3effcd147a7f7e1f632bdd67727R77-R88) [[4]](diffhunk://#diff-61bf200863ca1adb54d7fa64bc1aafcf84547f3fd3f20db81ae2e3799b88ca77L73-R77)

**Operational and Recovery Documentation**

* Documented the recovery posture, including the routine reboot exercise, the separation of the rescue user from normal admin flows, and the checklist for verifying recovery readiness. [[1]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782R271-R278) [[2]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782R318) [[3]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782R337-R344)
* Captured operational lessons learned during recent networking and recovery incidents, emphasizing the importance of a console-capable user and the validated rescue workflow. [[1]](diffhunk://#diff-522bf533200e1c7005156fe6bfcdedcbbb3dd3effcd147a7f7e1f632bdd67727R52-R58) [[2]](diffhunk://#diff-522bf533200e1c7005156fe6bfcdedcbbb3dd3effcd147a7f7e1f632bdd67727R77-R88)

**Spec and Change Tracking**

* Added an openspec change record for the host recovery baseline.

These changes collectively provide a robust, auditable, and routinely exercised recovery path for remote hosts, aligning operational practice with the repository’s declarative and feature-oriented philosophy.