### PR TITLE
feat: added syncthing web ui at subpath for oci-melb-1 host

### DIFF
--- a/.tmp/external-context/.manifest.json
+++ b/.tmp/external-context/.manifest.json
@@ -1,1 +1,17 @@
-{"libraries":{"restic":{"files":[{"filename":"restic-s3-r2-notes.md","topic":"s3-custom-endpoint-r2","tech_stack":"NixOS/Linux","fetched":"2026-05-05T00:00:00Z","source":"Context7 + official restic docs"}]}}}
+{
+  "version": 1,
+  "last_updated": "2026-05-06T00:00:00Z",
+  "libraries": {
+    "chillweb": {
+      "files": [
+        {
+          "filename": "syncthing-widgets.md",
+          "topic": "syncthing-widgets",
+          "tech_stack": "Homepage",
+          "fetched": "2026-05-06T00:00:00Z",
+          "source": "Official docs page"
+        }
+      ]
+    }
+  }
+}

--- a/.tmp/external-context/chillweb/syncthing-widgets.md
+++ b/.tmp/external-context/chillweb/syncthing-widgets.md
@@ -1,0 +1,41 @@
+---
+source: Official docs page
+library: Homepage / Syncthing Widgets
+package: chillweb
+topic: syncthing-widgets
+fetched: 2026-05-06T00:00:00Z
+official_docs: https://www.chillweb.net/homepage/syncthing_widgets
+---
+
+## What it provides
+- A custom Homepage `customapi` widget setup for Syncthing.
+- Shows basic Syncthing summary stats from `/rest/svc/report`: stored MB, folders, files, devices.
+- Shows recent Syncthing errors from `/rest/system/error` as a dynamic list.
+
+## Multi-host / multi-instance support
+- The example is written for one Syncthing endpoint (`http://192.0.2.0:8384`).
+- No explicit multi-host or multi-instance abstraction is shown.
+- Likely supports multiple instances only by defining multiple widget entries manually.
+
+## API / auth requirements
+- Needs Syncthing REST API access.
+- Uses `X-API-Key` header with a Homepage secret variable.
+- Assumes Homepage can reach the Syncthing API endpoint directly on the network.
+- Example uses plain HTTP to port 8384.
+
+## Replacement vs dashboard
+- It is a dashboard summary only.
+- Not a replacement for the Syncthing Web UI.
+- The Syncthing UI is still needed for detailed device/folder management and troubleshooting.
+
+## Fit for this repo
+- Good fit later if you want lightweight Syncthing status tiles inside Homepage.
+- Probably requires a per-host Syncthing API secret and reachable endpoint for each instance.
+- If Syncthing UIs are already exposed via subpaths/Tailscale, this widget is still separate: it polls REST API, not the web UI.
+
+## Risks / limitations
+- Single-endpoint example; multi-host setup is manual.
+- Exposes REST API usage, so secret handling matters.
+- Basic stats only; error list is limited.
+- Assumes Homepage can reach the Syncthing API directly.
+- Plain HTTP in the example may be unsuitable depending on your network posture.

--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {

--- a/hosts/do-admin-1/edge.nix
+++ b/hosts/do-admin-1/edge.nix
@@ -17,6 +17,7 @@ let
       upstream
       ;
     forceTrailingSlash = svc.forceTrailingSlash or false;
+    upstreamHostHeader = svc.upstreamHostHeader or "{host}";
     upstreamTlsInsecure = svc.upstreamTlsInsecure or false;
     upstreamTlsCaCertFile = svc.upstreamTlsCaCertFile or null;
     upstreamTlsServerName = svc.upstreamTlsServerName or null;

--- a/modules/services/admin/homepage/data.nix
+++ b/modules/services/admin/homepage/data.nix
@@ -191,8 +191,8 @@ in
           Syncthing = {
             icon = "syncthing";
             description = "Cross-host file sync controller";
-            href = serviceHref "syncthing-admin";
-            siteMonitor = (requireRoute "syncthing-admin").healthUrl;
+            href = serviceHref "syncthing-oci-melb-1";
+            siteMonitor = (requireRoute "syncthing-oci-melb-1").healthUrl;
           };
         }
       ];

--- a/modules/services/edge-proxy-ingress.nix
+++ b/modules/services/edge-proxy-ingress.nix
@@ -67,7 +67,7 @@ let
           ${accessGuard}
           ${responseHeaders}
           reverse_proxy ${route.upstream} {
-            header_up Host {host}
+            header_up Host ${route.upstreamHostHeader}
             header_up X-Forwarded-Proto {scheme}
             header_up X-Forwarded-For {remote_host}
             ${upstreamTransport}
@@ -77,11 +77,12 @@ let
     else if route.stripPrefix then
       ''
         # ${name} (${route.exposureMode})
+        ${lib.optionalString route.forceTrailingSlash "redir ${route.path} ${route.path}/ 308"}
         handle_path ${route.path}* {
           ${accessGuard}
           ${responseHeaders}
           reverse_proxy ${route.upstream} {
-            header_up Host {host}
+            header_up Host ${route.upstreamHostHeader}
             header_up X-Forwarded-Proto {scheme}
             header_up X-Forwarded-For {remote_host}
             ${upstreamTransport}
@@ -97,7 +98,7 @@ let
           ${accessGuard}
           ${responseHeaders}
           reverse_proxy ${route.upstream} {
-            header_up Host {host}
+            header_up Host ${route.upstreamHostHeader}
             header_up X-Forwarded-Proto {scheme}
             header_up X-Forwarded-For {remote_host}
             ${upstreamTransport}
@@ -346,6 +347,12 @@ in
               description = "Optional response headers injected before proxying for this route.";
             };
 
+            upstreamHostHeader = lib.mkOption {
+              type = lib.types.str;
+              default = "{host}";
+              description = "Value used for the upstream Host header when proxying this route.";
+            };
+
             authenticatedOriginPullsRequired = lib.mkOption {
               type = lib.types.bool;
               default = true;
@@ -431,7 +438,7 @@ in
         domain = cfg.primaryDomain;
         extraDomainNames = certExtraDomains;
         dnsProvider = "cloudflare";
-        credentialsFile = cfg.cloudflareCredentialsFile;
+        environmentFile = cfg.cloudflareCredentialsFile;
         group = "caddy";
       };
     };

--- a/openspec/changes/archive/2026-05-06-add-syncthing-subpath-webuis/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-06-add-syncthing-subpath-webuis/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/archive/2026-05-06-add-syncthing-subpath-webuis/design.md
+++ b/openspec/changes/archive/2026-05-06-add-syncthing-subpath-webuis/design.md
@@ -1,0 +1,58 @@
+## Context
+
+`oci-melb-1` already runs Syncthing successfully, and the repository already models admin/browser routes through `policy/web-services.nix` plus shared edge-ingress rendering. Today the Syncthing GUI remains loopback-bound at `127.0.0.1:8384`, which is operationally safe but inconvenient for browser access. The repo already has a proven path-based admin route pattern for Cockpit (`/do-admin-1`, `/oci-melb-1`), and Syncthing’s own reverse-proxy guidance supports serving the GUI behind a subpath while proxying to localhost.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a private-first path-based routing pattern for Syncthing UIs under `syncthing.shrublab.xyz`.
+- Keep each host’s Syncthing GUI loopback-bound rather than exposing it on `0.0.0.0`.
+- Reuse existing policy/edge-ingress composition so future Syncthing hosts can be added declaratively.
+- Preserve a clean operator surface for Homepage/admin links.
+
+**Non-Goals:**
+- Introduce a fleet dashboard such as Homepage widgets or `sm2` in this change.
+- Make Syncthing publicly reachable without existing access controls.
+- Rework broader edge-ingress architecture beyond what is needed for Syncthing subpath support.
+
+## Decisions
+
+### Decision D1 — Use shared-host subpaths instead of per-host subdomains
+- **Choice:** Model Syncthing browser entrypoints as path-based routes such as `/oci-melb-1/` under `syncthing.shrublab.xyz`.
+- **Why:** Cloudflare free-plan constraints make nested subdomains undesirable, and the repo already supports path-based admin routes.
+- **Alternative considered:** Per-host subdomains were cleaner in isolation, but they do not fit the current DNS/edge constraints.
+
+### Decision D2 — Bind Syncthing to a private-network-reachable address and keep exposure Tailscale-only
+- **Choice:** Bind Syncthing to a non-loopback address reachable over the host's private network posture so the edge can proxy to it directly over Tailscale.
+- **Why:** This keeps the runtime simple, matches the fleet's non-edge Tailscale-only exposure model, and avoids adding an extra proxy hop solely to preserve loopback binding.
+- **Alternative considered:** Keeping Syncthing on `127.0.0.1:8384` with a host-local proxy hop would work, but it adds moving parts without a clear benefit under the current fleet posture.
+
+### Decision D3 — Use path-prefix stripping in the proxy layer
+- **Choice:** Route Syncthing subpaths through the existing ingress model using prefix stripping before proxying upstream.
+- **Why:** Syncthing’s documented reverse-proxy pattern handles subpaths in the proxy, and the repo already has `stripPrefix` support in edge-ingress rendering.
+- **Alternative considered:** Adding host-local rewrite glue or moving Syncthing to dedicated per-host hostnames would add complexity without solving a current repo constraint.
+
+### Decision D4 — Keep the change focused on access wiring, not dashboards
+- **Choice:** Implement only native Syncthing UI access in this change.
+- **Why:** We need reliable host admin access first; dashboards can layer on later once the canonical route shape exists.
+- **Alternative considered:** Adding `sm2` or Homepage at the same time would mix UI aggregation with lower-level access plumbing.
+
+## Risks / Trade-offs
+
+- **[Risk]** Syncthing may behave differently behind stripped subpaths than other admin apps. → **Mitigation:** validate with the native UI, API requests, and redirects using the repo’s existing path-route pattern plus official Syncthing proxy guidance.
+- **[Risk]** Shared-host route ordering could cause path collisions. → **Mitigation:** keep host-specific paths explicit and rely on the ingress renderer’s longest-path-first ordering.
+- **[Risk]** Future multi-host Syncthing additions may duplicate manual route wiring. → **Mitigation:** capture the route pattern in specs/tasks now so later hosts follow the same structure.
+- **[Risk]** Homepage/admin links may still point at the old root route. → **Mitigation:** update consuming links as part of the implementation tasks.
+
+## Migration Plan
+
+1. Add canonical route/spec requirements for shared-host Syncthing subpaths.
+2. Update policy/runtime wiring so `syncthing.shrublab.xyz/<host>/` resolves to the correct private upstream.
+3. Keep Syncthing exposure private to the tailnet-facing origin path; do not introduce direct public ingress.
+4. Validate generated route metadata, ingress rendering, and resolved public URLs.
+5. Deploy to the edge/admin host and verify browser access plus API/UI behavior through the proxy.
+
+## Open Questions
+
+- Whether `do-admin-1` should get a concrete Syncthing host route in this first implementation or whether the change should scaffold the pattern with `oci-melb-1` first.
+- Whether upstream `Host` header handling for Syncthing should remain on the generic ingress default or be made explicitly route-specific during implementation.

--- a/openspec/changes/archive/2026-05-06-add-syncthing-subpath-webuis/proposal.md
+++ b/openspec/changes/archive/2026-05-06-add-syncthing-subpath-webuis/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Syncthing on `oci-melb-1` is syncing correctly, but its GUI is bound to `127.0.0.1:8384`, which makes browser access awkward for routine administration. We want a simple private-first way to reach host Syncthing UIs through the existing edge policy model without widening Syncthing's bind scope to `0.0.0.0`.
+
+## What Changes
+
+- Add declarative private admin routing for Syncthing web UIs using the existing `policy/web-services.nix` path-based route pattern.
+- Support a shared `syncthing.shrublab.xyz` admin surface with host-specific subpaths such as `/oci-melb-1/`.
+- Keep Syncthing GUIs private on each host's tailnet-reachable interface while making reverse-proxied access work correctly behind a subpath-aware configuration.
+- Reuse existing edge-ingress and policy resolution patterns so future Syncthing hosts can be added without inventing a separate exposure model.
+
+## Capabilities
+
+### New Capabilities
+- `syncthing-admin-access`: private, path-based browser access to per-host Syncthing web UIs through the canonical web policy and ingress model.
+
+### Modified Capabilities
+- `network-access`: add an explicit private-origin route pattern for host-specific Syncthing admin subpaths under a shared admin hostname.
+- `admin-services`: define that Syncthing admin access remains private-first and may be exposed through shared subpath browser entrypoints while keeping host-local GUIs loopback-bound.
+
+## Impact
+
+- Affected policy/runtime files will likely include `policy/web-services.nix`, route consumers under `modules/services/edge-proxy-ingress.nix`, and Syncthing service wiring.
+- Browser access for Syncthing administration will move from SSH tunneling/manual localhost access to declared reverse-proxied private routes.
+- Homepage/admin links may need to target the new canonical Syncthing route shape.

--- a/openspec/changes/archive/2026-05-06-add-syncthing-subpath-webuis/specs/admin-services/spec.md
+++ b/openspec/changes/archive/2026-05-06-add-syncthing-subpath-webuis/specs/admin-services/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: Syncthing admin browser access MAY use shared-host subpath entrypoints
+Syncthing administrative browser access SHALL remain private-first and MAY be exposed through shared-host subpath entrypoints rather than only root-host or tunnel-based access.
+
+#### Scenario: Operator opens Syncthing admin UI for a host
+- **WHEN** a host has a declared Syncthing admin browser route
+- **THEN** the operator can reach the host’s Syncthing UI through the canonical admin URL for that host-specific subpath
+- **AND** the access path remains compatible with existing private-origin and admin access controls

--- a/openspec/changes/archive/2026-05-06-add-syncthing-subpath-webuis/specs/network-access/spec.md
+++ b/openspec/changes/archive/2026-05-06-add-syncthing-subpath-webuis/specs/network-access/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: Shared admin hostnames MAY carry host-specific private-origin subpaths
+Private-origin admin services SHALL be able to share a public hostname while remaining distinguishable through explicit host-specific subpaths.
+
+#### Scenario: Multiple admin routes share a hostname
+- **WHEN** policy routes for different hosts use the same subdomain with distinct declared paths
+- **THEN** route resolution preserves the distinct public URLs for each host-specific subpath
+- **AND** upstream transport remains private-origin according to the declared exposure mode

--- a/openspec/changes/archive/2026-05-06-add-syncthing-subpath-webuis/specs/syncthing-admin-access/spec.md
+++ b/openspec/changes/archive/2026-05-06-add-syncthing-subpath-webuis/specs/syncthing-admin-access/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Syncthing admin browser access SHALL support host-specific subpaths
+The repository SHALL support per-host Syncthing browser entrypoints under a shared admin hostname using explicit path-based route declarations.
+
+#### Scenario: A host Syncthing route is resolved
+- **WHEN** the canonical web policy for an eligible host is resolved
+- **THEN** the host can declare a Syncthing admin route under the shared `syncthing` hostname with a host-specific path such as `/oci-melb-1/`
+- **AND** the resolved public URL preserves that host-specific subpath
+
+### Requirement: Syncthing admin proxying SHALL preserve private-only GUI exposure
+Syncthing browser access SHALL be delivered through reverse-proxy routing without requiring the host Syncthing GUI to be publicly exposed beyond the fleet's private-origin posture.
+
+#### Scenario: Syncthing GUI remains private-origin reachable
+- **WHEN** a Syncthing admin route is rendered for a host
+- **THEN** the upstream target may remain a host-private address such as `127.0.0.1:8384`, `0.0.0.0:8384`, or a tailnet-reachable host interface
+- **AND** the requirement does not force the Syncthing GUI to be exposed through direct public ingress
+
+### Requirement: Syncthing admin subpaths SHALL work with reverse-proxy prefix handling
+The Syncthing admin route model SHALL support reverse-proxy path-prefix handling compatible with Syncthing’s documented subpath hosting pattern.
+
+#### Scenario: A path-based Syncthing route is rendered
+- **WHEN** the ingress route for a host Syncthing UI uses a non-root path
+- **THEN** proxy behavior strips or otherwise handles the declared prefix so the upstream Syncthing UI remains reachable
+- **AND** redirects and API/UI requests continue to function through the declared route

--- a/openspec/changes/archive/2026-05-06-add-syncthing-subpath-webuis/tasks.md
+++ b/openspec/changes/archive/2026-05-06-add-syncthing-subpath-webuis/tasks.md
@@ -1,0 +1,15 @@
+## 1. Canonical route and Syncthing wiring
+
+- [x] 1.1 Update `policy/web-services.nix` so Syncthing admin uses the shared `syncthing` hostname with a host-specific subpath for `oci-melb-1`, following the existing path-based admin route pattern.
+- [x] 1.2 Adjust Syncthing/runtime ingress wiring as needed so reverse-proxy access works through the declared subpath while the GUI remains private-origin reachable on the host.
+
+## 2. Route consumers and operator surface
+
+- [x] 2.1 Update any route consumers or admin links that assume the old root Syncthing URL so they resolve to the new canonical subpath URL.
+- [x] 2.2 Verify the pattern remains reusable for future Syncthing hosts without requiring a different exposure model.
+
+## 3. Validation
+
+- [x] 3.1 Run targeted evaluation checks for resolved Syncthing public URL, ingress route rendering, and any Syncthing-specific route settings introduced by the change.
+- [x] 3.2 Run repo validation (`nix flake check` in the appropriate source mode and any targeted evals needed for the touched modules).
+- [x] 3.3 Run `openspec validate add-syncthing-subpath-webuis --strict` and confirm the change is ready for implementation.

--- a/openspec/specs/admin-services/spec.md
+++ b/openspec/specs/admin-services/spec.md
@@ -270,3 +270,11 @@ Stateful admin services that require application-aware recovery, including Kanid
 - **THEN** each service defines or consumes export-first backup behavior
 - **AND** Kanidm may satisfy that contract with its upstream automatic backup artifact while the initial backup payload still includes generated recovery artifacts and raw service state
 
+### Requirement: Syncthing admin browser access MAY use shared-host subpath entrypoints
+Syncthing administrative browser access SHALL remain private-first and MAY be exposed through shared-host subpath entrypoints rather than only root-host or tunnel-based access.
+
+#### Scenario: Operator opens Syncthing admin UI for a host
+- **WHEN** a host has a declared Syncthing admin browser route
+- **THEN** the operator can reach the host’s Syncthing UI through the canonical admin URL for that host-specific subpath
+- **AND** the access path remains compatible with existing private-origin and admin access controls
+

--- a/openspec/specs/network-access/spec.md
+++ b/openspec/specs/network-access/spec.md
@@ -73,3 +73,11 @@ Cloudflare resource declarations SHALL be owned in control-plane artifacts, whil
 - **WHEN** runtime/Nix change needs edge policy values
 - **THEN** values are consumed from canonical policy and generated outputs rather than duplicated unmanaged config
 
+### Requirement: Shared admin hostnames MAY carry host-specific private-origin subpaths
+Private-origin admin services SHALL be able to share a public hostname while remaining distinguishable through explicit host-specific subpaths.
+
+#### Scenario: Multiple admin routes share a hostname
+- **WHEN** policy routes for different hosts use the same subdomain with distinct declared paths
+- **THEN** route resolution preserves the distinct public URLs for each host-specific subpath
+- **AND** upstream transport remains private-origin according to the declared exposure mode
+

--- a/openspec/specs/syncthing-admin-access/spec.md
+++ b/openspec/specs/syncthing-admin-access/spec.md
@@ -1,0 +1,29 @@
+# syncthing-admin-access Specification
+
+## Purpose
+TBD - created by archiving change add-syncthing-subpath-webuis. Update Purpose after archive.
+## Requirements
+### Requirement: Syncthing admin browser access SHALL support host-specific subpaths
+The repository SHALL support per-host Syncthing browser entrypoints under a shared admin hostname using explicit path-based route declarations.
+
+#### Scenario: A host Syncthing route is resolved
+- **WHEN** the canonical web policy for an eligible host is resolved
+- **THEN** the host can declare a Syncthing admin route under the shared `syncthing` hostname with a host-specific path such as `/oci-melb-1/`
+- **AND** the resolved public URL preserves that host-specific subpath
+
+### Requirement: Syncthing admin proxying SHALL preserve private-only GUI exposure
+Syncthing browser access SHALL be delivered through reverse-proxy routing without requiring the host Syncthing GUI to be publicly exposed beyond the fleet's private-origin posture.
+
+#### Scenario: Syncthing GUI remains private-origin reachable
+- **WHEN** a Syncthing admin route is rendered for a host
+- **THEN** the upstream target may remain a host-private address such as `127.0.0.1:8384`, `0.0.0.0:8384`, or a tailnet-reachable host interface
+- **AND** the requirement does not force the Syncthing GUI to be exposed through direct public ingress
+
+### Requirement: Syncthing admin subpaths SHALL work with reverse-proxy prefix handling
+The Syncthing admin route model SHALL support reverse-proxy path-prefix handling compatible with Syncthing’s documented subpath hosting pattern.
+
+#### Scenario: A path-based Syncthing route is rendered
+- **WHEN** the ingress route for a host Syncthing UI uses a non-root path
+- **THEN** proxy behavior strips or otherwise handles the declared prefix so the upstream Syncthing UI remains reachable
+- **AND** redirects and API/UI requests continue to function through the declared route
+

--- a/policy/web-services.nix
+++ b/policy/web-services.nix
@@ -191,13 +191,17 @@
           health.path = "/v1/health";
         };
 
-        syncthing-admin = {
+        syncthing-oci-melb-1 = {
           subdomain = "syncthing";
+          path = "/oci-melb-1";
+          forceTrailingSlash = true;
+          stripPrefix = true;
           origin = {
             scheme = "http";
             host = "oci-melb-1.tail0fe19b.ts.net";
             port = 8384;
           };
+          upstreamHostHeader = "{upstream_hostport}";
           exposureMode = "tailscale-upstream";
           category = "admin";
         };


### PR DESCRIPTION
This pull request introduces a new pattern for Syncthing admin UI access, enabling private, path-based browser access for each host under a shared `syncthing.shrublab.xyz` hostname. The implementation updates both policy and runtime wiring to support host-specific subpaths, refines edge-proxy configuration for more flexible upstream Host header handling, and updates admin links to point to the new canonical routes. Several specification and documentation files are added to formalize requirements, decisions, and migration steps for this model.

**Syncthing Admin UI Subpath Routing**

* Added a new declarative pattern for Syncthing admin browser access: each host's Syncthing UI is now accessible at a unique subpath under the shared `syncthing.shrublab.xyz` hostname (e.g., `/oci-melb-1/`), keeping GUIs private and not exposed to the public internet. [[1]](diffhunk://#diff-c3237f49ed08eb11b6247a6f353a6c5aae22e09fe3d29912c55ced0f6d5caa2fR1-R58) [[2]](diffhunk://#diff-e75841c35ffbeef8b13da73b3905d095a071971e5eb5940cd8b0ea137722cb57R1-R25) [[3]](diffhunk://#diff-0304fb8b738363278270586d11e907939d1e3066855111d825bab474ed156710R1-R9) [[4]](diffhunk://#diff-3543c6bec2c04e87394ca2fd6d1889f993cd58aa1a2d718b505ceb08bd0c00eaR1-R9) [[5]](diffhunk://#diff-e3f0000b7c77998a508182b07bf80aacd4ffe7b8626dc46ff6dcc321ba53c388R1-R25) [[6]](diffhunk://#diff-90e34d4fb02879ea687a0e0da0c0bfab4cf6de9c227e2831149848ce2d101644R1-R15) [[7]](diffhunk://#diff-ec7dfba4982e81a2645a9edfbb8db1f6782f1b9045c6bd92245077b67a1f8672R273-R280) [[8]](diffhunk://#diff-9f9dffc3a588e755b66458fea17ae089fc7f24a81be31c2a241ac0960583557dR76-R83)

**Edge Proxy and Routing Improvements**

* Introduced a new `upstreamHostHeader` option in the edge-proxy ingress module, allowing per-route control of the Host header sent upstream, and updated all reverse proxy invocations to use this configurable value instead of the hardcoded `{host}`. [[1]](diffhunk://#diff-2ef5ac45ef8abcadc8370f8d295b2c87c3ce050e5a807803104fb231260cdce5L70-R70) [[2]](diffhunk://#diff-2ef5ac45ef8abcadc8370f8d295b2c87c3ce050e5a807803104fb231260cdce5R80-R85) [[3]](diffhunk://#diff-2ef5ac45ef8abcadc8370f8d295b2c87c3ce050e5a807803104fb231260cdce5L100-R101) [[4]](diffhunk://#diff-2ef5ac45ef8abcadc8370f8d295b2c87c3ce050e5a807803104fb231260cdce5R350-R355) [[5]](diffhunk://#diff-cd31156ec3c45cfcfb4ffe018cdbf6028d1f77e703982689a94561ae7fdbe4f8R20)
* Updated certificate resource configuration to use `environmentFile` instead of `credentialsFile` for Cloudflare DNS provider integration.

**Admin Surface / Homepage Link Updates**

* Updated the Homepage service metadata for Syncthing to point to the new canonical host-specific subpath route rather than the old root route, ensuring operator links resolve correctly.

**Documentation and Specification**

* Added OpenSpec design, proposal, requirements, and tasks documents to capture the rationale, requirements, and migration plan for Syncthing subpath web UI access. [[1]](diffhunk://#diff-c3237f49ed08eb11b6247a6f353a6c5aae22e09fe3d29912c55ced0f6d5caa2fR1-R58) [[2]](diffhunk://#diff-e75841c35ffbeef8b13da73b3905d095a071971e5eb5940cd8b0ea137722cb57R1-R25) [[3]](diffhunk://#diff-0304fb8b738363278270586d11e907939d1e3066855111d825bab474ed156710R1-R9) [[4]](diffhunk://#diff-3543c6bec2c04e87394ca2fd6d1889f993cd58aa1a2d718b505ceb08bd0c00eaR1-R9) [[5]](diffhunk://#diff-e3f0000b7c77998a508182b07bf80aacd4ffe7b8626dc46ff6dcc321ba53c388R1-R25) [[6]](diffhunk://#diff-90e34d4fb02879ea687a0e0da0c0bfab4cf6de9c227e2831149848ce2d101644R1-R15) [[7]](diffhunk://#diff-65fd61a4a016295bf71480a176f86b67df01ca57e47203cb34f1d2b28d2a6654R1-R2)
* Added an external context manifest and documentation describing a Syncthing widget for Homepage, clarifying its capabilities and limitations. [[1]](diffhunk://#diff-c662db8ff18b5b1e7f967a2a12d630f275fb10e88faa8f5527748d6b95994bf1L1-R17) [[2]](diffhunk://#diff-8862e625d93ecb6db9566aa014042e3249f4b22ea5205ad41c3c3cbbd722f117R1-R41)

These changes together enable secure, maintainable, and scalable Syncthing admin access for the fleet, while formalizing the approach for future hosts.