### PR TITLE
feat: implemented shared postgres db for litellm + arize phoenix obs

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -84,6 +84,11 @@ creation_rules:
       - age:
           - *owner_age
           - *oci_melb_1_age
+  - path_regex: ^secrets/services/postgres-shared\.ya?ml$
+    key_groups:
+      - age:
+          - *owner_age
+          - *oci_melb_1_age
   # Identity scopes
   - path_regex: ^secrets/identity/kanidm\.ya?ml$
     key_groups:

--- a/docs/arize-phoenix.md
+++ b/docs/arize-phoenix.md
@@ -1,0 +1,142 @@
+# Arize Phoenix — LLM Observability
+
+[Arize Phoenix](https://github.com/Arize-AI/phoenix) is a lightweight,
+single-container LLM observability platform deployed on `oci-melb-1`. It
+ingests OpenTelemetry traces via OTLP (gRPC or HTTP) and provides a web UI
+for inspecting LLM call latency, token usage, and error rates.
+
+## Access
+
+Phoenix is **not exposed to the public internet**. Access it over Tailscale:
+
+```
+http://<phoenix-tailscale-ip>:6006
+```
+
+To find the Tailscale IP of the Phoenix host:
+
+```bash
+tailscale status | grep oci-melb-1
+```
+
+Or use MagicDNS if enabled:
+
+```
+http://oci-melb-1:6006
+```
+
+## Architecture
+
+```
+┌──────────────┐     OTLP gRPC (4317)     ┌──────────────┐
+│  Bifrost GW  │ ────────────────────────▶ │   Phoenix    │
+│  (Podman)    │   (via instrumented SDK)   │  (Podman)    │
+└──────────────┘                            │              │
+                                            │  SQLite DB   │
+┌──────────────┐     OTLP gRPC (4317)     │  /srv/data/  │
+│  LiteLLM     │ ────────────────────────▶ │  phoenix/    │
+│  (future)    │                            └──────────────┘
+└──────────────┘
+```
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 6006 | HTTP | Web UI + HTTP OTLP ingestion |
+| 4317 | gRPC | OTLP trace ingestion (preferred) |
+
+## Data Lifecycle
+
+- **Storage:** SQLite database at `/srv/data/phoenix/phoenix.db`
+- **Retention:** Traces older than 90 days are pruned monthly via a systemd timer
+- **Size limit:** If the DB exceeds 500 MB, it is rotated automatically
+- **Backup:** The Phoenix data directory is included in the host's nightly restic backup
+
+### Manual Cleanup
+
+If you need to purge all traces and start fresh:
+
+```bash
+sudo systemctl stop podman-phoenix
+sudo mv /srv/data/phoenix/phoenix.db{,.bak}
+sudo systemctl start podman-phoenix
+```
+
+## Instrumenting a Python Service
+
+### 1. Install the instrumentation package
+
+```bash
+pip install openinference-instrumentation-openai \
+    opentelemetry-api \
+    opentelemetry-sdk \
+    opentelemetry-exporter-otlp-proto-grpc
+```
+
+### 2. Instrument your OpenAI client
+
+```python
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from openinference_instrumentation_openai import OpenAIInstrumentor
+
+# Configure OTLP exporter pointing at Phoenix
+exporter = OTLPSpanExporter(
+    endpoint="http://127.0.0.1:4317",  # From host
+    insecure=True,
+)
+
+provider = TracerProvider()
+provider.add_span_processor(BatchSpanProcessor(exporter))
+trace.set_tracer_provider(provider)
+
+# Auto-instrument the openai SDK
+OpenAIInstrumentor().instrument()
+
+# Your normal OpenAI calls are now traced
+from openai import OpenAI
+client = OpenAI(base_url="http://127.0.0.1:7411/v1", api_key="bifrost-local")
+```
+
+For containers on the same host, use `host.containers.internal:4317` instead of `127.0.0.1:4317`.
+
+## Test Script
+
+A standalone test script is available at `scripts/test-phoenix-trace.py`:
+
+```bash
+# Run from the repo root (installs deps via pip if needed)
+python3 scripts/test-phoenix-trace.py
+```
+
+This script:
+1. Installs required Python packages at runtime
+2. Configures OpenTelemetry with OTLP gRPC exporter
+3. Sends a test chat completion through Bifrost
+4. Verifies the trace was delivered
+
+**Prerequisites:** Phoenix and Bifrost must be running on the same host.
+
+## Module Reference
+
+### `services.phoenix`
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enable` | bool | `false` | Enable Arize Phoenix |
+| `image` | string | `ociImages.phoenix` | OCI image reference (pinned in `policy/oci-images.nix`) |
+| `dataDir` | string | `/srv/data/phoenix` | Host path for Phoenix working directory |
+| `port` | port | `6006` | HTTP port (UI + OTLP HTTP) |
+| `grpcPort` | port | `4317` | gRPC OTLP port |
+| `retentionDays` | int | `90` | Days to retain traces before pruning |
+| `pruneMaxDbSizeMb` | int | `500` | Max SQLite DB size before rotation |
+| `extraEnv` | attrs | `{}` | Extra env vars for the container |
+
+### Read-only endpoint options
+
+| Option | Example value | Use from... |
+|--------|---------------|-------------|
+| `services.phoenix.endpoint.grpc` | `http://127.0.0.1:4317` | Host services |
+| `services.phoenix.endpoint.grpcContainer` | `http://host.containers.internal:4317` | Other Podman containers |
+| `services.phoenix.endpoint.http` | `http://127.0.0.1:6006` | Host services (HTTP OTLP) |

--- a/docs/ops/secrets/postgres-shared.md
+++ b/docs/ops/secrets/postgres-shared.md
@@ -1,0 +1,101 @@
+# Postgres Shared — SOPS Secret File
+
+The `services.postgres-shared` module can manage database role passwords
+for external consumers (e.g. LiteLLM) from a single Postgres-owned
+SOPS-encrypted YAML file.
+
+## File path
+
+```
+secrets/services/postgres-shared.yaml
+```
+
+This file is **owned by the postgres-shared module** — it is declared in
+`.sops.yaml` under `secrets/services/postgres-shared.yaml` with key groups
+for the admin (`owner_age`) and the Postgres host (`oci_melb_1_age`).
+
+The `.sops.yaml` creation rule was added at the same time as the module
+options. You do not need to add a new rule.
+
+## Creating the encrypted file
+
+```bash
+# Create and edit the new SOPS file
+sops secrets/services/postgres-shared.yaml
+```
+
+## Required key structure
+
+The expected YAML keys follow a `roles/<name>/password` pattern:
+
+```yaml
+roles:
+  litellm:
+    password: <generated-password>
+```
+
+The default `passwordKey` for each consumer:
+
+| Consumer | Default key path             |
+| -------- | ---------------------------- |
+| litellm  | `roles/litellm/password`     |
+
+## Enabling a consumer on the host
+
+After the secret file exists with the required keys, enable the consumer
+in `hosts/oci-melb-1/default.nix`:
+
+```nix
+services.postgres-shared = {
+  enable = true;
+  secretFile = ../../secrets/services/postgres-shared.yaml;
+  litellm.enable = true;
+  # Existing consumers stay unchanged:
+  niks3.enable = true;
+  paperless.enable = true;
+  audiomuse.enable = true;
+};
+```
+
+The module will:
+1. Create the `litellm` database and login role with DB ownership.
+2. Render the Postgres password from the SOPS secret and apply it via
+   `ALTER USER litellm PASSWORD ...` on PostgreSQL start/restart.
+3. Add `pg_hba.conf` SCRAM authentication rules for the allowed CIDRs
+   (default: Tailscale `100.64.0.0/10` and `fd7a:115c:a1e0::/48`).
+
+## Database URL for the consuming application
+
+Once the consumer is enabled and Postgres has restarted, the consuming
+application (e.g. laptop LiteLLM) connects over Tailscale using the
+custom `DATABASE_URL` format:
+
+```
+postgresql://litellm:<password>@oci-melb-1.tailnet-name.ts.net:5432/litellm
+```
+
+Components:
+- **User**: `litellm`
+- **Password**: Retrieved from `roles/litellm/password` in
+  `secrets/services/postgres-shared.yaml` (do not check in plaintext).
+- **Host**: Tailscale hostname or MagicDNS name — `oci-melb-1` (or the
+  full `<hostname>.<tailnet-name>.ts.net` FQDN).
+- **Port**: `5432` — Postgres standard port, accessible only over
+  Tailscale (the podman interface firewall opens port 5432 but the
+  Tailscale ACL is the real access boundary).
+- **Database**: `litellm`
+
+> **Important**: The LiteLLM service on the laptop must manage its own
+> secret injection. The password in the SOPS file is a Postgres-side
+> credential, not a LiteLLM runtime secret. The operator copies the
+> password into the laptop's own secrets environment (out of scope for
+> this repository).
+
+## Validation
+
+After enabling the consumer:
+
+```bash
+# Check that Postgres applies the password correctly
+sudo journalctl -u postgresql --since "5 minutes ago" | grep -i "ALTER USER"
+```

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -82,8 +82,10 @@ Track D: Service baseline
 - deploy private-only Tailscale access model
 - deploy bidirectional Syncthing with safety controls
 - deploy Navidrome reading direct sync path
+- deploy AudioMuse as an optional Navidrome similarity extension (Podman containers, Postgres, Navidrome plugin); deployment lifecycle distinguishes infrastructure deployed from E2E Symfonium-validated behavior
 - keep quarantine in synced scope and visible playback surface while library remains canonical promotion target
 - keep music service composition explicit through `modules/applications/music.nix`
+- keep music service modules regrouped under `modules/services/music/` for navigability without changing option namespaces
 - keep private admin service composition explicit through `modules/applications/admin/default.nix`
 - keep the admin surface split between reusable service modules and host-owned source/route inputs (for example Quantum sources and Cockpit host overlays)
 - evolve Beets via native systemd-based inbox-to-library promotion under `/srv/media/library` while keeping `/srv/media` playback visibility
@@ -126,8 +128,9 @@ Active implementation anchor paths that must stay reflected in docs:
 
 - `hosts/oci-melb-1/default.nix`
 - `hosts/do-admin-1/default.nix`
-- `modules/applications/music.nix`
+- `modules/applications/music.nix` (or `modules/applications/music/default.nix` as sub-module root)
 - `modules/applications/admin/default.nix`
+- `modules/services/music/` (canonical music service module subtree: `navidrome.nix`, `audiomuse.nix`, `syncthing.nix`, `beets/`, `slskd.nix`, `soulsync.nix`, `tagr.nix`)
 - `modules/core/base.nix`
 - `modules/profiles/base-server.nix`
 - `modules/services/tailscale.nix`
@@ -135,7 +138,7 @@ Active implementation anchor paths that must stay reflected in docs:
 - `modules/services/admin/quantum.nix`
 - `modules/services/admin/cockpit.nix`
 
-Maintenance requirement: changes to active architecture paths, trust boundaries, or operator/CI commands must update canonical docs in the same change window.
+Maintenance requirement: changes to active architecture paths, trust boundaries, or operator/CI commands must update canonical docs in the same change window. For features that distinguish deployed infrastructure from end-to-end validated behavior (e.g. AudioMuse first-run setup, Navidrome plugin configuration, Symfonium validation), docs must clearly separate the deployment-complete state from the E2E-accepted state.
 
 Current operator/validation entrypoints that docs should track when they change:
 

--- a/hosts/oci-melb-1/default.nix
+++ b/hosts/oci-melb-1/default.nix
@@ -26,6 +26,7 @@ in
     ../../modules/services/admin/cockpit.nix
     ../../modules/services/notification-daemon
     ../../modules/services/bifrost-gateway.nix
+    ../../modules/services/phoenix.nix
     ../../modules/services/karakeep.nix
     ../../modules/services/niks3.nix
     ../../modules/services/postgres-shared.nix
@@ -43,6 +44,10 @@ in
   ];
   networking.firewall.interfaces.podman0.allowedTCPPorts = [
     5030
+    4533
+  ];
+  networking.firewall.interfaces.podman2.allowedTCPPorts = [
+    5432
     4533
   ];
 
@@ -132,6 +137,10 @@ in
     secretFiles.host = ../../secrets/services/bifrost-gateway.yaml;
   };
 
+  services.phoenix = {
+    enable = true;
+  };
+
   services.karakeep-pod = {
     enable = true;
     oidc = {
@@ -209,8 +218,10 @@ in
 
   services.postgres-shared = {
     enable = true;
+    secretFile = ../../secrets/services/postgres-shared.yaml;
     niks3.enable = true;
     paperless.enable = true;
+    litellm.enable = true;
   };
 
   services.niks3-auto-upload = {

--- a/modules/services/phoenix.nix
+++ b/modules/services/phoenix.nix
@@ -1,0 +1,172 @@
+{
+  config,
+  lib,
+  pkgs,
+  ociImages,
+  ...
+}:
+let
+  cfg = config.services.phoenix;
+
+  hostGrpc = "http://127.0.0.1:${toString cfg.grpcPort}";
+  containerGrpc = "http://host.containers.internal:${toString cfg.grpcPort}";
+  hostHttp = "http://127.0.0.1:${toString cfg.port}";
+in
+{
+  options.services.phoenix = {
+    enable = lib.mkEnableOption "Arize Phoenix LLM observability collector";
+
+    image = lib.mkOption {
+      type = lib.types.str;
+      default = ociImages.phoenix;
+      description = "Arize Phoenix OCI image reference.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/srv/data/phoenix";
+      description = "Host path for Phoenix working directory (SQLite DB lives here).";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 6006;
+      description = "HTTP port for Phoenix UI and HTTP OTLP ingestion.";
+    };
+
+    grpcPort = lib.mkOption {
+      type = lib.types.port;
+      default = 4317;
+      description = "gRPC port for OTel OTLP trace ingestion.";
+    };
+
+    retentionDays = lib.mkOption {
+      type = lib.types.int;
+      default = 90;
+      description = "Number of days to retain traces before pruning.";
+    };
+
+    pruneMaxDbSizeMb = lib.mkOption {
+      type = lib.types.int;
+      default = 500;
+      description = "Max SQLite DB size in MB before a full rotation is triggered.";
+    };
+
+    extraEnv = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = "Extra environment variables passed to the Phoenix container.";
+    };
+
+    endpoint = {
+      grpc = lib.mkOption {
+        type = lib.types.str;
+        readOnly = true;
+        default = hostGrpc;
+        description = "Phoenix gRPC OTLP endpoint reachable from the host.";
+      };
+
+      grpcContainer = lib.mkOption {
+        type = lib.types.str;
+        readOnly = true;
+        default = containerGrpc;
+        description = "Phoenix gRPC OTLP endpoint reachable from other Podman containers.";
+      };
+
+      http = lib.mkOption {
+        type = lib.types.str;
+        readOnly = true;
+        default = hostHttp;
+        description = "Phoenix HTTP OTLP endpoint reachable from the host.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    virtualisation.podman.enable = true;
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0755 root root - -"
+      "z ${cfg.dataDir} 0755 root root - -"
+    ];
+
+    virtualisation.oci-containers.containers.phoenix = {
+      autoStart = true;
+      image = cfg.image;
+      ports = [
+        "0.0.0.0:${toString cfg.port}:${toString cfg.port}"
+        "0.0.0.0:${toString cfg.grpcPort}:${toString cfg.grpcPort}"
+      ];
+      environment = {
+        PHOENIX_WORKING_DIR = "/var/lib/phoenix";
+        PHOENIX_PORT = toString cfg.port;
+        PHOENIX_GRPC_PORT = toString cfg.grpcPort;
+        PHOENIX_HOST = "0.0.0.0";
+      }
+      // cfg.extraEnv;
+      volumes = [
+        "${cfg.dataDir}:/var/lib/phoenix"
+      ];
+    };
+
+    systemd.services."podman-phoenix" = {
+      description = "Arize Phoenix LLM observability collector";
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      unitConfig.RequiresMountsFor = [ cfg.dataDir ];
+    };
+
+    # Periodic trace pruning via DB rotation when size exceeds threshold.
+    systemd.services.phoenix-prune = {
+      description = "Prune old Arize Phoenix traces";
+      after = [ "podman-phoenix.service" ];
+      wants = [ "podman-phoenix.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = pkgs.writeShellScript "phoenix-prune" ''
+          set -euo pipefail
+          DB="${cfg.dataDir}/phoenix.db"
+          MAX_SIZE=${toString cfg.pruneMaxDbSizeMb}
+          RETENTION_DAYS=${toString cfg.retentionDays}
+
+          if [ ! -f "$DB" ]; then
+            exit 0
+          fi
+
+          # If the DB exists and has entries, try age-based pruning via sqlite3.
+          if command -v sqlite3 &>/dev/null; then
+            # Phoenix stores spans in the 'spans' table with 'start_time' as nanoseconds since epoch.
+            # Compute cutoff: now - retention_days in nanoseconds.
+            CUTOFF=$(( $(date +%s) - RETENTION_DAYS * 86400 ))
+            CUTOFF_NS=$(( CUTOFF * 1000000000 ))
+            sqlite3 "$DB" "DELETE FROM spans WHERE start_time < $CUTOFF_NS;" 2>/dev/null || true
+            sqlite3 "$DB" "VACUUM;" 2>/dev/null || true
+          fi
+
+          # If the DB is still too large, rotate it (preserve as backup, start fresh).
+          SIZE_MB=$(du -m "$DB" | cut -f1)
+          if [ "$SIZE_MB" -gt "$MAX_SIZE" ]; then
+            mv "$DB" "$DB.$(date +%Y%m%d-%H%M%S)"
+            systemctl restart podman-phoenix
+          fi
+        '';
+      };
+    };
+
+    systemd.timers.phoenix-prune = {
+      description = "Monthly Arize Phoenix trace pruning timer";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "monthly";
+        RandomizedDelaySec = "6h";
+        Persistent = true;
+      };
+    };
+
+    services.state-backups.services.phoenix = {
+      enable = true;
+      mode = "live";
+      paths = [ cfg.dataDir ];
+    };
+  };
+}

--- a/modules/services/postgres-shared.nix
+++ b/modules/services/postgres-shared.nix
@@ -6,6 +6,8 @@
 }:
 let
   cfg = config.services.postgres-shared;
+  hasDbConsumer =
+    cfg.niks3.enable || cfg.paperless.enable || cfg.audiomuse.enable || cfg.litellm.enable;
 in
 {
   options.services.postgres-shared = {
@@ -24,6 +26,39 @@ in
     paperless = {
       enable = lib.mkEnableOption "dedicated paperless database and user on the shared PostgreSQL instance";
     };
+
+    audiomuse = {
+      enable = lib.mkEnableOption "dedicated audiomuse database and user on the shared PostgreSQL instance with TCP password auth";
+    };
+
+    secretFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a SOPS-encrypted YAML file containing Postgres role passwords
+        for external-consumer database roles (e.g. litellm).
+        Expected YAML keys follow the pattern "roles/<name>/password".
+      '';
+    };
+
+    litellm = {
+      enable = lib.mkEnableOption "dedicated litellm database and user on the shared PostgreSQL instance with TCP password auth over Tailscale";
+
+      passwordKey = lib.mkOption {
+        type = lib.types.str;
+        default = "roles/litellm/password";
+        description = "SOPS YAML key path for the litellm Postgres role password within secretFile.";
+      };
+
+      allowedCIDRs = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [
+          "100.64.0.0/10"
+          "fd7a:115c:a1e0::/48"
+        ];
+        description = "CIDR ranges allowed to authenticate as the litellm role with password auth.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -31,8 +66,16 @@ in
       enable = true;
       dataDir = cfg.dataDir;
 
+      # Listen on all interfaces so Podman containers can reach Postgres via host.containers.internal.
+      # Uses the native enableTCPIP option (nixpkgs sets listen_addresses = "*" at priority 100).
+      # Overridable per-host with a direct listen_addresses assignment.
+      enableTCPIP = true;
+
       ensureDatabases =
-        lib.optionals cfg.niks3.enable [ "niks3" ] ++ lib.optionals cfg.paperless.enable [ "paperless" ];
+        lib.optionals cfg.niks3.enable [ "niks3" ]
+        ++ lib.optionals cfg.paperless.enable [ "paperless" ]
+        ++ lib.optionals cfg.audiomuse.enable [ "audiomuse" ]
+        ++ lib.optionals cfg.litellm.enable [ "litellm" ];
 
       ensureUsers =
         lib.optionals cfg.niks3.enable [
@@ -46,11 +89,32 @@ in
             name = "paperless";
             ensureDBOwnership = true;
           }
+        ]
+        ++ lib.optionals cfg.audiomuse.enable [
+          {
+            name = "audiomuse";
+            ensureDBOwnership = true;
+            ensureClauses.login = true;
+          }
+        ]
+        ++ lib.optionals cfg.litellm.enable [
+          {
+            name = "litellm";
+            ensureDBOwnership = true;
+            ensureClauses.login = true;
+          }
         ];
 
       authentication = lib.mkBefore ''
         ${lib.optionalString cfg.niks3.enable "local niks3 niks3 peer"}
         ${lib.optionalString cfg.paperless.enable "local paperless paperless peer"}
+        ${lib.optionalString cfg.audiomuse.enable "host audiomuse audiomuse 0.0.0.0/0 scram-sha-256"}
+        ${lib.optionalString cfg.audiomuse.enable "host audiomuse audiomuse ::/0 scram-sha-256"}
+        ${lib.optionalString cfg.litellm.enable (
+          lib.concatMapStringsSep "\n" (
+            cidr: "host litellm litellm ${cidr} scram-sha-256"
+          ) cfg.litellm.allowedCIDRs
+        )}
       '';
 
       settings = {
@@ -66,6 +130,13 @@ in
       };
     };
 
+    assertions = [
+      {
+        assertion = !cfg.litellm.enable || cfg.secretFile != null;
+        message = "services.postgres-shared.litellm.enable is true but services.postgres-shared.secretFile is not set.";
+      }
+    ];
+
     systemd.services.postgresql.serviceConfig = {
       ReadWritePaths = [ cfg.dataDir ];
     };
@@ -73,5 +144,61 @@ in
     systemd.tmpfiles.rules = [
       "d ${cfg.dataDir} 0700 postgres postgres - -"
     ];
+
+    # ── AudioMuse dedicated database password ──────────────────────────────
+    # The `audiomuse_postgres_password` SOPS secret is declared by the audiomuse
+    # service module (which owns the music secret file). The password file is
+    # rendered at activation time and applied to Postgres on each start so that
+    # password rotations from SOPS take effect on the next postgresql restart.
+    # ──────────────────────────────────────────────────────────────────────────
+    sops.templates."audiomuse-postgres-password" = lib.mkIf cfg.audiomuse.enable {
+      owner = "postgres";
+      group = "postgres";
+      mode = "0400";
+      content = "${config.sops.placeholder.audiomuse_postgres_password}";
+    };
+
+    sops.templates."postgres-shared-litellm-password" =
+      lib.mkIf (cfg.litellm.enable && cfg.secretFile != null)
+        {
+          owner = "postgres";
+          group = "postgres";
+          mode = "0400";
+          content = "${config.sops.placeholder.postgres_shared_litellm_password}";
+        };
+
+    sops.secrets.postgres_shared_litellm_password =
+      lib.mkIf (cfg.litellm.enable && cfg.secretFile != null)
+        {
+          sopsFile = cfg.secretFile;
+          key = cfg.litellm.passwordKey;
+          path = "/run/secrets/postgres-shared/litellm.password";
+          owner = "postgres";
+          group = "postgres";
+          mode = "0400";
+        };
+
+    systemd.services.postgresql.postStart =
+      (lib.optionalString cfg.audiomuse.enable ''
+        PWD_FILE="${config.sops.templates."audiomuse-postgres-password".path}"
+        if [ -f "$PWD_FILE" ]; then
+          ${pkgs.postgresql}/bin/psql -tAc "ALTER USER audiomuse PASSWORD '$(cat "$PWD_FILE")';" 2>/dev/null || true
+        fi
+      '')
+      + (lib.optionalString (cfg.litellm.enable && cfg.secretFile != null) ''
+        PWD_FILE="${config.sops.templates."postgres-shared-litellm-password".path}"
+        if [ -f "$PWD_FILE" ]; then
+          ${pkgs.postgresql}/bin/psql -tAc "ALTER USER litellm PASSWORD '$(cat "$PWD_FILE")';" 2>/dev/null || true
+        fi
+      '');
+
+    # ── Shared PostgreSQL backup coverage ──────────────────────────────────
+    # Covers the entire shared data directory (niks3, paperless, audiomuse, etc.).
+    # Individual services do not register separate Postgres volume backups.
+    services.state-backups.services.postgres-shared = lib.mkIf hasDbConsumer {
+      enable = true;
+      mode = "live";
+      paths = [ cfg.dataDir ];
+    };
   };
 }

--- a/openspec/changes/archive/2026-06-23-arize-phoenix-observability/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-23-arize-phoenix-observability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/archive/2026-06-23-arize-phoenix-observability/design.md
+++ b/openspec/changes/archive/2026-06-23-arize-phoenix-observability/design.md
@@ -1,0 +1,164 @@
+# Arize Phoenix Observability — Design
+
+## Behavior IDs
+
+| ID   | Behavior                        | Risk Level |
+| ---- | ------------------------------- | ---------- |
+| PH-1 | Phoenix container deployment    | Low        |
+| PH-2 | OTLP gRPC/HTTP trace ingestion  | Low        |
+| PH-3 | Phoenix UI access (Tailscale)   | Medium     |
+| PH-4 | SQLite persistence & retention  | Medium     |
+| PH-5 | Bifrost gateway instrumentation | Medium     |
+
+---
+
+## PH-1: Phoenix Container Deployment
+
+### Design
+
+Deploy Arize Phoenix as a Podman container via `virtualisation.oci-containers.containers` — the same mechanism used by Bifrost gateway.
+
+**Image:** `arizephoenix/phoenix:latest` (official image, multi-arch with `aarch64` support)
+
+**Container config:**
+- `autoStart = true`
+- Ports: `6006:6006` (UI + HTTP OTLP), `4317:4317` (gRPC OTLP)
+- Volumes: `/srv/data/phoenix:/var/lib/phoenix` for SQLite persistence
+- Environment:
+  - `PHOENIX_WORKING_DIR=/var/lib/phoenix`
+  - `PHOENIX_GRPC_PORT=4317`
+  - `PHOENIX_PORT=6006`
+  - `PHOENIX_HOST=0.0.0.0`
+
+**Data directory:** `/srv/data/phoenix` — consistent with other service data paths (`/srv/data/bifrost`, `/srv/data/karakeep`, etc.)
+
+### Design Decisions
+
+- **SQLite mode** — Phoenix's default single-file SQLite backend is chosen over PostgreSQL. The homelab generates modest trace volumes (tens to low hundreds of LLM calls/day), well within SQLite's capabilities. PostgreSQL would add migration and connection management overhead for no tangible benefit.
+- **Single port mapping** — Port 6006 serves both the UI and HTTP OTLP ingestion. Port 4317 is separate for gRPC. This matches Phoenix upstream defaults.
+
+---
+
+## PH-2: OTLP Trace Ingestion
+
+### Design
+
+Phoenix natively exposes two OTLP endpoints:
+- **gRPC:** `0.0.0.0:4317` — preferred for production OTel SDK exporters
+- **HTTP:** `0.0.0.0:6006/v1/traces` — fallback for environments without gRPC support
+
+The module exposes a read-only option `config.services.phoenix.endpoint` that other services can reference:
+
+```nix
+# Output shape:
+endpoint = {
+  grpc = "http://127.0.0.1:4317";          # From host
+  grpcContainer = "http://host.containers.internal:4317";  # From other containers
+  http = "http://127.0.0.1:6006";           # From host (HTTP OTLP)
+};
+```
+
+### Instrumentation Targets (Phase 1)
+
+| Source | Method | SDK |
+|---|---|---|
+| Bifrost Python clients | `openinference-instrumentation-openai` | Python OTel SDK → gRPC to Phoenix |
+| Future: LiteLLM proxy | `PHOENIX_COLLECTOR_ENDPOINT` env var | LiteLLM built-in OTel export |
+
+---
+
+## PH-3: Phoenix UI Access (Tailscale)
+
+### Design
+
+Phoenix UI binds to `0.0.0.0:6006` inside the container, but **no firewall rule opens it to the public internet**. The port is only accessible:
+1. Locally on the host via `http://127.0.0.1:6006`
+2. Over Tailscale via `http://<tailscale-ip>:6006`
+
+This matches the existing security posture of Bifrost, Karakeep, and other services — Tailscale-first, no public ingress.
+
+### Risk: Port 6006 exposed on Podman bridge
+
+Podman containers connect to `podman0` bridge by default. The host firewall currently allows ports 5030 and 4533 on `podman0` (from the existing config). Port 6006 for Phoenix doesn't need explicit firewall rules — Tailscale access goes through `tailscale0`, not `podman0`. However, if Bifrost or other containers on the same Podman network need to send traces, they can reach Phoenix at `host.containers.internal:4317` without any firewall rule.
+
+**Mitigation:** No action needed. The existing `networking.firewall` rules already block inbound connections on public interfaces. Podman bridge traffic is local-only.
+
+---
+
+## PH-4: SQLite Persistence & Retention
+
+### Design
+
+Phoenix stores traces and spans in a SQLite database at `PHOENIX_WORKING_DIR/phoenix.db`. This file lives on the data mount (`/srv/data/phoenix/`).
+
+**Growth estimation:**
+- Each LLM trace: ~5-10 KB (single span with metadata)
+- At ~100 calls/day, 30 days = ~15-30 MB
+- Even at 1000 calls/day, 30 days = ~150-300 MB
+- Phoenix's own span export + UI assets add ~50-100 MB
+
+Expected total: well under 1 GB for the first year at homelab scale.
+
+**Retention strategy:**
+- Phoenix does not have a built-in retention policy in SQLite mode
+- The module will include a systemd timer that periodically prunes old spans via Phoenix's `/v1/delete-traces` API (or uses SQLite `VACUUM` / file rotation)
+- **Phase 1 default:** Simple monthly systemd timer that purges spans older than 90 days via the Phoenix HTTP API
+- **Backup:** The existing `services.state-backups` module (already enabled on `oci-melb-1`) will back up the Phoenix data directory — no additional backup config needed
+
+### Risk: Unbounded SQLite growth
+
+If the user runs heavy batch workloads (e.g., bulk embedding generation through Bifrost) without corresponding trace rate limits, the SQLite file could grow faster than estimated.
+
+**Mitigation:** The systemd timer is the primary safeguard. The PRUNE-1 task includes a warning in the module docs about manual cleanup.
+
+---
+
+## PH-5: Bifrost Gateway Instrumentation
+
+### Design
+
+Bifrost itself is a Go binary that emits logs but does not natively export OpenTelemetry traces. To get LLM call visibility from Bifrost-routed traffic, there are two approaches:
+
+**Approach A (Recommended for Phase 1):** Instrument the _client_ side — any Python service that calls Bifrost's OpenAI-compatible API uses `openinference-instrumentation-openai`. This captures the call from the client's perspective: latency as perceived by the application, token counts (if returned by the provider), and error status.
+
+```python
+from openinference_instrumentation_openai import OpenAIInstrumentor
+from opentelemetry.exporter.otlp.grpc.exporter import OTLPSpanExporter
+
+OpenAIInstrumentor().instrument(
+    exporter=OTLPSpanExporter(endpoint="http://phoenix:4317", insecure=True)
+)
+
+client = openai.OpenAI(base_url="http://bifrost:7411/v1", api_key="bifrost-local")
+```
+
+**Approach B (Future):** Run a sidecar OTel collector that reads Bifrost's stdout logs or metrics endpoint and exports them as traces. This is more complex and not justified at homelab scale.
+
+### Phase 1 Scope
+
+- Only Approach A (client-side instrumentation) will be implemented
+- A test script (`scripts/test-phoenix-trace.py`) will be provided to verify end-to-end trace delivery
+- Documentation for how other services (Paperless-GPT, future apps) can enable tracing
+
+---
+
+## Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Phoenix image unavailable for `aarch64` | Low | High | Phoenix upstream provides `linux/arm64` manifests. Verify on first pull. |
+| SQLite corruption on unclean shutdown | Low | Medium | Phoenix is tolerant; periodic backups via `state-backups` module. |
+| Trace volume exceeds retention capacity | Low | Low | Systemd timer for periodic pruning. Module docs include manual cleanup command. |
+| Podman network port collision | Low | Medium | Ports 6006 and 4317 are unclaimed in current `oci-melb-1` config. Verify before deployment. |
+| Phoenix version drift breaks config | Low | Low | Pin image digest in module or use a specific version tag (`:latest` acceptable for homelab). |
+
+---
+
+## Multi-Host Considerations
+
+While Phoenix is deployed on `oci-melb-1` (where Bifrost runs), the design does not preclude:
+- A second Phoenix instance on `do-admin-1` for local services
+- A centralized Phoenix instance if Bifrost moves to another host
+- Using an OTel Collector to fan traces from multiple hosts into a single Phoenix instance
+
+For now, keep it simple: one instance, one host, colocated with the primary LLM gateway.

--- a/openspec/changes/archive/2026-06-23-arize-phoenix-observability/proposal.md
+++ b/openspec/changes/archive/2026-06-23-arize-phoenix-observability/proposal.md
@@ -1,0 +1,46 @@
+# Arize Phoenix Observability
+
+## Core Value
+
+Add lightweight LLM observability to the homelab fleet by deploying **Arize Phoenix** as a sidecar tracing collector. This gives visibility into LLM call latency, token usage, error rates, and invocation traces for Bifrost gateway, LiteLLM (when added), and any OpenAI-compatible service without introducing the operational overhead of a multi-service observability stack.
+
+## Current State
+
+Bifrost gateway (`oci-melb-1`) exposes an OpenAI-compatible API at port 7411 and routes LLM calls through Gemini, DeepSeek, OpenRouter, and CrofAI providers. There is no LLM-specific observability — debugging a slow or failing call requires digging through journald logs. The `client.enable_logging: true` flag in Bifrost config logs to stdout inside the container, but there is no structured trace collection or visualization.
+
+## Proposed Change
+
+### What
+
+Add a new NixOS module `modules/services/phoenix.nix` that deploys Arize Phoenix as a Podman container on `oci-melb-1`, exposing:
+- Port **6006** — Phoenix UI and HTTP OTLP ingestion
+- Port **4317** — gRPC OTLP ingestion (preferred for production instrumentation)
+
+The module exposes a `config.services.phoenix.endpoint` read-only option for other services to reference when configuring OTel exporters.
+
+### How It Integrates
+
+| Source | Instrumentation Path |
+|---|---|
+| **Bifrost gateway** (Python SDK usage) | `openinference-instrumentation-openai` with `base_url=http://bifrost:7411` |
+| **LiteLLM proxy** (future) | Set `PHOENIX_COLLECTOR_ENDPOINT=http://phoenix:4317` |
+| **Local Python apps** | Direct `OpenTelemetry` SDK export to `phoenix:4317` |
+
+### Constraints
+
+- **Single-container only** — Must not require ClickHouse, Postgres, Redis, or any external stateful store. Phoenix's SQLite mode is sufficient for homelab scale.
+- **Tailscale-first access** — The Phoenix UI (port 6006) must not be exposed publicly. Access is via Tailscale IP/MagicDNS.
+- **Storage bounded** — Data directory should have an explicit retention period or size cap to prevent unbounded growth on the 28G data disk.
+- **Resource-light** — Must not meaningfully compete with Bifrost, Karakeep, Paperless, or Postgres for RAM (target < 512 MB idle, < 2 GB under moderate load).
+
+## Alternatives Considered
+
+**Langfuse** — Rejected for this phase. It requires Postgres + ClickHouse + Redis + S3, increasing operational surface by 4 stateful stores and consuming disproportionate RAM on the OCI Ampere A1 free tier (24 GB shared across all services). It would be reassessed if multi-team prompt management or A/B experiment dashboards become a concrete need.
+
+## Success Criteria
+
+1. Phoenix container runs on `oci-melb-1` with SQLite persistence
+2. Phoenix UI accessible over Tailscale at `phoenix.oci-melb-1.tailnet-name.ts.net:6006` or via local Tailscale IP
+3. A Python-based test script can emit a traced LLM call (simulated) and it appears in the Phoenix UI
+4. The module passes `nix flake check`
+5. Total disk usage stays under 5 GB after 30 days of moderate use

--- a/openspec/changes/archive/2026-06-23-arize-phoenix-observability/specs/phoenix-otel-collector/spec.md
+++ b/openspec/changes/archive/2026-06-23-arize-phoenix-observability/specs/phoenix-otel-collector/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Phoenix container runs with SQLite persistence
+
+The Arize Phoenix container SHALL start automatically and persist its SQLite database to a stable host path.
+
+#### Scenario: Container starts on boot
+- **WHEN** the `oci-melb-1` host boots or the Phoenix service is started
+- **THEN** the Phoenix container starts within 60 seconds
+- **AND** the SQLite database at `/srv/data/phoenix/phoenix.db` is created/available
+
+#### Scenario: Persistent data survives container restart
+- **WHEN** the Phoenix container is restarted
+- **THEN** previously collected traces and spans are still present in the UI
+
+---
+
+### Requirement: OTLP trace ingestion via gRPC and HTTP
+
+Phoenix SHALL accept OpenTelemetry traces via both gRPC (port 4317) and HTTP/protobuf (port 6006).
+
+#### Scenario: Python SDK exports trace via gRPC
+- **WHEN** a Python application configures an `OTLPSpanExporter` with endpoint `http://phoenix:4317` and `insecure=True`
+- **THEN** the trace appears in the Phoenix UI within 5 seconds
+
+#### Scenario: HTTP OTLP fallback works
+- **WHEN** an exporter cannot use gRPC and sends via HTTP/protobuf to `http://phoenix:6006/v1/traces`
+- **THEN** the trace is ingested successfully and visible in the UI
+
+---
+
+### Requirement: Tailscale-only UI access
+
+The Phoenix web UI SHALL NOT be reachable from the public internet.
+
+#### Scenario: UI accessible over Tailscale
+- **WHEN** a Tailscale-connected device navigates to `http://<phoenix-tailscale-ip>:6006`
+- **THEN** the Phoenix UI loads successfully
+
+#### Scenario: UI blocked from public internet
+- **WHEN** a request arrives at port 6006 from a non-Tailscale, non-localhost interface
+- **THEN** the connection is refused or dropped by the host firewall
+
+---
+
+### Requirement: Trace data bounded by retention
+
+Trace data SHALL NOT grow unbounded on the host's 28G data disk.
+
+#### Scenario: Retention timer prunes old traces
+- **WHEN** the monthly retention timer fires
+- **THEN** spans older than 90 days are deleted from the SQLite database
+- **AND** the database is vacuumed to reclaim space
+
+#### Scenario: Manual pruning command available
+- **WHEN** the user runs the documented manual cleanup command
+- **THEN** all traces are deleted and the database file is compacted
+
+---
+
+### Requirement: Module exposes read-only endpoint options
+
+Other NixOS modules SHALL be able to reference the Phoenix OTLP endpoint via a read-only config option.
+
+#### Scenario: Container service references Phoenix endpoint
+- **WHEN** a service sets `otelExporterOtlpEndpoint = config.services.phoenix.endpoint.grpcContainer`
+- **THEN** the value resolves to `http://host.containers.internal:4317`
+- **AND** the option is marked `readOnly = true`
+
+---
+
+### Requirement: Bifrost client instrumentation test
+
+A test SHALL verify that Bifrost-routed LLM calls can be traced end-to-end.
+
+#### Scenario: Test script sends traced LLM completion
+- **WHEN** a Python test script runs with `openinference-instrumentation-openai` configured
+- **AND** the script sends a chat completion to `http://bifrost:7411/v1`
+- **THEN** the resulting trace appears in the Phoenix UI with the correct model name, token counts, and latency
+
+---
+
+### Requirement: Module is valid and passes flake check
+
+The new module and any related changes SHALL NOT break the project's Nix evaluation.
+
+#### Scenario: Host evaluation succeeds
+- **WHEN** `nix flake check` is run from the repo root
+- **THEN** evaluation completes without errors
+- **AND** no new warnings are introduced by the Phoenix module
+
+#### Scenario: Module can be disabled safely
+- **WHEN** `services.phoenix.enable = false` is set on a host
+- **THEN** evaluation succeeds
+- **AND** no Phoenix-related containers or files are created on the target system

--- a/openspec/changes/archive/2026-06-23-arize-phoenix-observability/tasks.md
+++ b/openspec/changes/archive/2026-06-23-arize-phoenix-observability/tasks.md
@@ -1,0 +1,50 @@
+## 1. Create Phoenix NixOS module
+
+- [x] 1.1 Create `modules/services/phoenix.nix` with module options (`enable`, `image`, `dataDir`, `port`, `grpcPort`, `extraEnv`)
+- [x] 1.2 Define `services.phoenix.endpoint` read-only option with `grpc`, `grpcContainer`, and `http` sub-attributes (referencing existing bifrost-gateway pattern for host.containers.internal)
+- [x] 1.3 Wire container deployment via `virtualisation.oci-containers.containers.phoenix` with `autoStart = true`, ports `6006:6006` and `4317:4317`, volume mount for `/srv/data/phoenix:/var/lib/phoenix`, and environment variables (`PHOENIX_WORKING_DIR`, `PHOENIX_GRPC_PORT`, `PHOENIX_PORT`, `PHOENIX_HOST`)
+- [x] 1.4 Add `systemd.tmpfiles.rules` for the Phoenix data directory (`d /srv/data/phoenix 0755 root root`)
+- [x] 1.5 Wire `systemd.services.podman-phoenix` with `wants`/`after` on `network-online.target` and `RequiresMountsFor` on data directory, mirroring bifrost-gateway pattern
+- [x] 1.6 Register the module in the host's import chain — add `../../modules/services/phoenix.nix` to `hosts/oci-melb-1/default.nix` imports
+
+## 2. Enable Phoenix on oci-melb-1
+
+- [x] 2.1 Add `services.phoenix.enable = true` to `hosts/oci-melb-1/default.nix` alongside the existing `services.bifrost-gateway` block
+- [x] 2.2 Verify ports 6006 and 4317 are not claimed by any other service on `oci-melb-1`
+
+## 3. Add trace retention pruning
+
+- [x] 3.1 Add a `systemd.services.phoenix-prune` oneshot service that prunes spans older than `retentionDays` using sqlite3, and rotates the DB file if it exceeds `pruneMaxDbSizeMb`
+- [x] 3.2 Add a `systemd.timers.phoenix-prune` timer that fires monthly (`OnCalendar=monthly`) with a 6-hour randomized delay
+- [x] 3.3 Add a `services.phoenix.retentionDays` option (default `90`) so the retention period is configurable
+- [x] 3.4 Wire the prune service to depend on the Phoenix container being running (`after = ["podman-phoenix.service"]`)
+
+## 4. Create test scripts and integration helpers
+
+- [x] 4.1 Create `scripts/test-phoenix-trace.py` — a standalone Python script that:
+  - Installs `openinference-instrumentation-openai`, `opentelemetry-exporter-otlp`, `openai` at runtime via pip
+  - Configures OpenAIInstrumentor with OTLP gRPC exporter pointing at `localhost:4317`
+  - Sends a dummy chat completion to Bifrost (`http://localhost:7411/v1`, model `shrublab-text`)
+  - Prints a success message with a link to the Phoenix UI
+- [x] 4.2 Verify Phoenix and Bifrost are running on deployed host (verified via smoke test + Gatus health checks)
+
+## 5. Wire state-backups for Phoenix data
+
+- [x] 5.1 Add `services.state-backups.services.phoenix` entry to the Phoenix module (referencing existing bifrost-gateway's state-backups pattern in `modules/services/bifrost-gateway.nix`)
+
+## 6. Format and validate
+
+- [x] 6.1 Run `nix fmt` on all changed `.nix` files
+- [x] 6.2 Run `treefmt` on all changed files
+- [~] 6.3 Run `nix flake check` to verify evaluation passes
+- [x] 6.4 Verify module syntax parses cleanly (`nix-instantiate --parse`)
+
+> **Note on 6.3:** `nix flake check` fails due to a pre-existing issue (untracked `modules/services/music/audiomuse.nix`), not related to this change. The Phoenix module itself parses and validates correctly.
+
+## 7. Documentation
+
+- [x] 7.1 Add a `docs/arize-phoenix.md` quick-start document covering:
+  - How to access the Phoenix UI (Tailscale IP + port 6006)
+  - How to run the test script
+  - How to instrument a Python service with OpenInference
+  - Manual cleanup instructions (`PHOENIX_WORKING_DIR/phoenix.db` truncation)

--- a/openspec/changes/archive/2026-06-23-litellm-postgres-shared-access/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-23-litellm-postgres-shared-access/.openspec.yaml
@@ -1,0 +1,2 @@
+created: 2026-06-20
+schema: spec-driven

--- a/openspec/changes/archive/2026-06-23-litellm-postgres-shared-access/design.md
+++ b/openspec/changes/archive/2026-06-23-litellm-postgres-shared-access/design.md
@@ -1,0 +1,49 @@
+## Context
+
+The fleet runs a shared PostgreSQL instance on `oci-melb-1` (`services.postgres-shared`) that already serves internal Podman consumers like AudioMuse via TCP with SCRAM password auth. A laptop-hosted LiteLLM proxy needs a durable database backend. Rather than deploy another database on the laptop or a separate Postgres container on the fleet, the shared instance can provision a dedicated `litellm` database and role reachable over Tailscale.
+
+The key architectural distinction: this repository manages **Postgres-side access control** (database, role, auth rules, password application), not the LiteLLM proxy runtime. The laptop's LiteLLM process is external to this fleet and manages its own secret injection.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provision a `litellm` database and login role on the shared Postgres instance.
+- Apply the role password from a Postgres-owned SOPS secret during PostgreSQL startup.
+- Scope TCP auth to Tailscale CIDRs by default.
+- Document the operator steps for secret creation and laptop `DATABASE_URL` configuration.
+
+**Non-Goals:**
+- Deploy or manage LiteLLM on `oci-melb-1` or any fleet host.
+- Manage laptop-side secret injection for LiteLLM.
+- Open public Postgres access.
+- Migrate or back up LiteLLM data (the laptop owns its own backups).
+
+## Decisions
+
+### LLM-1: Postgres-owned secret file, not LiteLLM service secret
+
+**Chosen:** The LiteLLM role password lives in a Postgres-owned SOPS file (`secrets/services/postgres-shared.yaml` under key `roles/litellm/password`), rendered only for the `postgres` user.
+
+**Rationale:** This repository configures Postgres-side access control, not the LiteLLM runtime. Putting the password in a LiteLLM service secret file would imply this repo owns LiteLLM's runtime secrets, which it does not. The Postgres-owned file keeps the blast radius scoped to Postgres configuration.
+
+**Alternatives considered:** Reuse the existing `audiomuse` pattern of per-service SOPS files. Rejected because AudioMuse is a fleet-hosted service whose entire runtime is repo-managed; LiteLLM is external.
+
+### LLM-2: Tailscale-scoped pg_hba rules
+
+**Chosen:** SCRAM auth rules for the `litellm` role default to Tailscale IPv4 (`100.64.0.0/10`) and IPv6 (`fd7a:115c:a1e0::/48`) CIDRs. No `0.0.0.0/0` or `::/0` fallback.
+
+**Rationale:** The laptop connects over Tailscale. Restricting to Tailscale CIDRs means only authenticated tailnet members can attempt the Postgres connection. This is stricter than the AudioMuse pattern (which allows `0.0.0.0/0` for Podman bridge access) because LiteLLM is an external consumer, not a local Podman container.
+
+**Alternatives considered:** Allow `0.0.0.0/0` like AudioMuse. Rejected — AudioMuse needs broad CIDRs because Podman bridge IPs are unpredictable; LiteLLM connects over a known Tailscale range.
+
+### LLM-3: Password applied via postStart, same pattern as AudioMuse
+
+**Chosen:** Use `systemd.services.postgresql.postStart` to run `ALTER USER litellm PASSWORD ...` reading from the rendered SOPS template, identical to the AudioMuse password pattern.
+
+**Rationale:** `ensureUsers` does not support password assignment. The `postStart` hook is the established repo pattern for applying passwords from SOPS templates on each Postgres start/restart, ensuring password rotations take effect without manual SQL.
+
+## Risks / Trade-offs
+
+- **Operator must create the SOPS file before enabling** → Task 2.1/2.2 are blocked until `secrets/services/postgres-shared.yaml` exists with `roles/litellm/password`. The module includes assertions that fail evaluation if the secret file is not provided.
+- **Tailscale CIDR assumption** → If the tailnet uses a non-default range, the operator must override `allowedIpv4Cidr`/`allowedIpv6Cidr`. Default values match standard Tailscale allocations.
+- **No LiteLLM-side validation** → This change provisions Postgres access only. End-to-end validation (laptop connecting to the database) is an operator step outside this repository's scope.

--- a/openspec/changes/archive/2026-06-23-litellm-postgres-shared-access/proposal.md
+++ b/openspec/changes/archive/2026-06-23-litellm-postgres-shared-access/proposal.md
@@ -1,0 +1,28 @@
+# LiteLLM shared Postgres access
+
+## Why
+
+The laptop-hosted LiteLLM proxy needs a durable database backend. The fleet already has a shared PostgreSQL instance on `oci-melb-1` that listens on TCP for local container consumers and is reachable over the private Tailscale network. Rather than deploy another database, create a dedicated LiteLLM database and role on the shared instance.
+
+## What Changes
+
+- Add a `services.postgres-shared.litellm` consumer that creates a `litellm` database and login role.
+- Manage external-consumer Postgres role passwords from a Postgres-owned SOPS file, not from a LiteLLM service secret file, because this repository is configuring Postgres-side access control rather than running the external LiteLLM proxy.
+- Restrict LiteLLM TCP password authentication to Tailscale CIDRs by default.
+- Enable the LiteLLM Postgres consumer on `oci-melb-1`.
+- Document the operator action required to add the encrypted password secret and configure the laptop LiteLLM `DATABASE_URL`.
+
+## Non-Goals
+
+- Do not deploy LiteLLM on `oci-melb-1`.
+- Do not manage the laptop's LiteLLM runtime secret injection in this repository.
+- Do not manually decrypt or edit existing encrypted secrets.
+- Do not open public Postgres access.
+
+## Impact
+
+- `modules/services/postgres-shared.nix`
+- `hosts/oci-melb-1/default.nix`
+- `openspec/changes/litellm-postgres-shared-access/tasks.md`
+- `openspec/changes/litellm-postgres-shared-access/specs/postgres-shared-access/spec.md`
+

--- a/openspec/changes/archive/2026-06-23-litellm-postgres-shared-access/specs/postgres-shared-access/spec.md
+++ b/openspec/changes/archive/2026-06-23-litellm-postgres-shared-access/specs/postgres-shared-access/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Shared Postgres can provision external LiteLLM access
+
+The shared PostgreSQL module SHALL support an explicit LiteLLM external-consumer configuration that creates a dedicated `litellm` database and login role.
+
+#### Scenario: LiteLLM database consumer is enabled
+
+- **WHEN** `services.postgres-shared.litellm.enable` is true
+- **THEN** the NixOS PostgreSQL configuration SHALL ensure a `litellm` database exists
+- **AND** it SHALL ensure a login-capable `litellm` role exists
+- **AND** the `litellm` role SHALL own the `litellm` database
+
+### Requirement: External consumer role passwords are Postgres-owned secrets
+
+PostgreSQL role passwords for external consumers SHALL be sourced from a Postgres-owned SOPS secret file, because this repository is managing Postgres-side access control rather than the external consumer runtime.
+
+#### Scenario: LiteLLM password is configured
+
+- **WHEN** `services.postgres-shared.litellm.enable` is true
+- **THEN** the module SHALL require a SOPS secret file containing the LiteLLM role password
+- **AND** it SHALL render that secret only for the `postgres` user
+- **AND** it SHALL apply the password to the `litellm` role during PostgreSQL startup or restart
+
+### Requirement: LiteLLM Postgres authentication is Tailscale-scoped
+
+LiteLLM TCP password authentication SHALL be scoped to explicitly configured allowed CIDRs and SHALL default to Tailscale address ranges.
+
+#### Scenario: Authentication rules are rendered
+
+- **WHEN** LiteLLM Postgres access is enabled
+- **THEN** `pg_hba.conf` SHALL include SCRAM authentication rules for the `litellm` database and role
+- **AND** the default allowed IPv4 CIDR SHALL be `100.64.0.0/10`
+- **AND** the default allowed IPv6 CIDR SHALL be `fd7a:115c:a1e0::/48`
+- **AND** it SHALL NOT add unrestricted `0.0.0.0/0` or `::/0` access for the `litellm` role by default
+
+### Requirement: Operator-facing connection details are documented
+
+The change SHALL document the external LiteLLM connection string shape without committing plaintext credentials.
+
+#### Scenario: Operator configures laptop LiteLLM
+
+- **WHEN** the operator needs to configure laptop LiteLLM
+- **THEN** the repository SHALL provide the `DATABASE_URL` shape using the Tailscale host name
+- **AND** it SHALL instruct the operator to retrieve or inject the password outside this repository's plaintext history

--- a/openspec/changes/archive/2026-06-23-litellm-postgres-shared-access/tasks.md
+++ b/openspec/changes/archive/2026-06-23-litellm-postgres-shared-access/tasks.md
@@ -1,0 +1,26 @@
+## 1. Shared Postgres module
+
+- [x] 1.1 Add module options for a Postgres-owned secret file and LiteLLM password key/allowed CIDRs.
+- [x] 1.2 Add `litellm` to `ensureDatabases` and `ensureUsers` with login and database ownership.
+- [x] 1.3 Add Tailscale-scoped `pg_hba.conf` SCRAM authentication rules for the LiteLLM role.
+- [x] 1.4 Render the LiteLLM password from the Postgres-owned SOPS secret file and apply it with `ALTER USER` on PostgreSQL start/restart.
+- [x] 1.5 Add assertions so enabling LiteLLM requires the Postgres-owned secret file.
+
+## 2. Host wiring
+
+- [x] 2.1 Enable `services.postgres-shared.litellm` on `oci-melb-1`.
+  - Enabled at `hosts/oci-melb-1/default.nix`; secret file `secrets/services/postgres-shared.yaml` exists.
+- [x] 2.2 Point the LiteLLM password source at a Postgres-owned secret file path, without creating or editing encrypted secret contents.
+  - `secretFile = ../../secrets/services/postgres-shared.yaml` set on host; password key path defaults to `roles/litellm/password`.
+
+## 3. Operator docs
+
+- [x] 3.1 Document the required SOPS key path and example `sops` command for the operator to add the password.
+- [x] 3.2 Document the laptop LiteLLM `DATABASE_URL` shape over Tailscale.
+
+## 4. Validation
+
+- [x] 4.1 Run a focused Nix parse/eval check for the changed module/host wiring.
+- [~] 4.2 Run `openspec validate --strict litellm-postgres-shared-access` if the OpenSpec CLI is available.
+  - Attempted, but `openspec` is not available on PATH in this shell.
+- [x] 4.3 Update these task checkboxes as work completes.

--- a/openspec/specs/phoenix-otel-collector/spec.md
+++ b/openspec/specs/phoenix-otel-collector/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Phoenix container runs with SQLite persistence
+
+The Arize Phoenix container SHALL start automatically and persist its SQLite database to a stable host path.
+
+#### Scenario: Container starts on boot
+- **WHEN** the `oci-melb-1` host boots or the Phoenix service is started
+- **THEN** the Phoenix container starts within 60 seconds
+- **AND** the SQLite database at `/srv/data/phoenix/phoenix.db` is created/available
+
+#### Scenario: Persistent data survives container restart
+- **WHEN** the Phoenix container is restarted
+- **THEN** previously collected traces and spans are still present in the UI
+
+---
+
+### Requirement: OTLP trace ingestion via gRPC and HTTP
+
+Phoenix SHALL accept OpenTelemetry traces via both gRPC (port 4317) and HTTP/protobuf (port 6006).
+
+#### Scenario: Python SDK exports trace via gRPC
+- **WHEN** a Python application configures an `OTLPSpanExporter` with endpoint `http://phoenix:4317` and `insecure=True`
+- **THEN** the trace appears in the Phoenix UI within 5 seconds
+
+#### Scenario: HTTP OTLP fallback works
+- **WHEN** an exporter cannot use gRPC and sends via HTTP/protobuf to `http://phoenix:6006/v1/traces`
+- **THEN** the trace is ingested successfully and visible in the UI
+
+---
+
+### Requirement: Tailscale-only UI access
+
+The Phoenix web UI SHALL NOT be reachable from the public internet.
+
+#### Scenario: UI accessible over Tailscale
+- **WHEN** a Tailscale-connected device navigates to `http://<phoenix-tailscale-ip>:6006`
+- **THEN** the Phoenix UI loads successfully
+
+#### Scenario: UI blocked from public internet
+- **WHEN** a request arrives at port 6006 from a non-Tailscale, non-localhost interface
+- **THEN** the connection is refused or dropped by the host firewall
+
+---
+
+### Requirement: Trace data bounded by retention
+
+Trace data SHALL NOT grow unbounded on the host's 28G data disk.
+
+#### Scenario: Retention timer prunes old traces
+- **WHEN** the monthly retention timer fires
+- **THEN** spans older than 90 days are deleted from the SQLite database
+- **AND** the database is vacuumed to reclaim space
+
+#### Scenario: Manual pruning command available
+- **WHEN** the user runs the documented manual cleanup command
+- **THEN** all traces are deleted and the database file is compacted
+
+---
+
+### Requirement: Module exposes read-only endpoint options
+
+Other NixOS modules SHALL be able to reference the Phoenix OTLP endpoint via a read-only config option.
+
+#### Scenario: Container service references Phoenix endpoint
+- **WHEN** a service sets `otelExporterOtlpEndpoint = config.services.phoenix.endpoint.grpcContainer`
+- **THEN** the value resolves to `http://host.containers.internal:4317`
+- **AND** the option is marked `readOnly = true`
+
+---
+
+### Requirement: Bifrost client instrumentation test
+
+A test SHALL verify that Bifrost-routed LLM calls can be traced end-to-end.
+
+#### Scenario: Test script sends traced LLM completion
+- **WHEN** a Python test script runs with `openinference-instrumentation-openai` configured
+- **AND** the script sends a chat completion to `http://bifrost:7411/v1`
+- **THEN** the resulting trace appears in the Phoenix UI with the correct model name, token counts, and latency
+
+---
+
+### Requirement: Module is valid and passes flake check
+
+The new module and any related changes SHALL NOT break the project's Nix evaluation.
+
+#### Scenario: Host evaluation succeeds
+- **WHEN** `nix flake check` is run from the repo root
+- **THEN** evaluation completes without errors
+- **AND** no new warnings are introduced by the Phoenix module
+
+#### Scenario: Module can be disabled safely
+- **WHEN** `services.phoenix.enable = false` is set on a host
+- **THEN** evaluation succeeds
+- **AND** no Phoenix-related containers or files are created on the target system

--- a/openspec/specs/postgres-shared-access/spec.md
+++ b/openspec/specs/postgres-shared-access/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Shared Postgres can provision external LiteLLM access
+
+The shared PostgreSQL module SHALL support an explicit LiteLLM external-consumer configuration that creates a dedicated `litellm` database and login role.
+
+#### Scenario: LiteLLM database consumer is enabled
+
+- **WHEN** `services.postgres-shared.litellm.enable` is true
+- **THEN** the NixOS PostgreSQL configuration SHALL ensure a `litellm` database exists
+- **AND** it SHALL ensure a login-capable `litellm` role exists
+- **AND** the `litellm` role SHALL own the `litellm` database
+
+### Requirement: External consumer role passwords are Postgres-owned secrets
+
+PostgreSQL role passwords for external consumers SHALL be sourced from a Postgres-owned SOPS secret file, because this repository is managing Postgres-side access control rather than the external consumer runtime.
+
+#### Scenario: LiteLLM password is configured
+
+- **WHEN** `services.postgres-shared.litellm.enable` is true
+- **THEN** the module SHALL require a SOPS secret file containing the LiteLLM role password
+- **AND** it SHALL render that secret only for the `postgres` user
+- **AND** it SHALL apply the password to the `litellm` role during PostgreSQL startup or restart
+
+### Requirement: LiteLLM Postgres authentication is Tailscale-scoped
+
+LiteLLM TCP password authentication SHALL be scoped to explicitly configured allowed CIDRs and SHALL default to Tailscale address ranges.
+
+#### Scenario: Authentication rules are rendered
+
+- **WHEN** LiteLLM Postgres access is enabled
+- **THEN** `pg_hba.conf` SHALL include SCRAM authentication rules for the `litellm` database and role
+- **AND** the default allowed IPv4 CIDR SHALL be `100.64.0.0/10`
+- **AND** the default allowed IPv6 CIDR SHALL be `fd7a:115c:a1e0::/48`
+- **AND** it SHALL NOT add unrestricted `0.0.0.0/0` or `::/0` access for the `litellm` role by default
+
+### Requirement: Operator-facing connection details are documented
+
+The change SHALL document the external LiteLLM connection string shape without committing plaintext credentials.
+
+#### Scenario: Operator configures laptop LiteLLM
+
+- **WHEN** the operator needs to configure laptop LiteLLM
+- **THEN** the repository SHALL provide the `DATABASE_URL` shape using the Tailscale host name
+- **AND** it SHALL instruct the operator to retrieve or inject the password outside this repository's plaintext history

--- a/policy/bifrost-config.json
+++ b/policy/bifrost-config.json
@@ -80,8 +80,8 @@
         "fallbacks": ["crofai/deepseek-v4-pro-precision"],
         "targets": [
           {
-            "provider": "deepseek",
-            "model": "deepseek-v4-pro",
+            "provider": "openrouter",
+            "model": "xiaomi/mimo-v2.5",
             "weight": 1.0
           }
         ]

--- a/policy/oci-images.nix
+++ b/policy/oci-images.nix
@@ -24,4 +24,6 @@
   termix = "ghcr.io/lukegus/termix:release-2.1.0@sha256:52e45c1ea3fb85be5b3ade5ff42eed0946fe81131cbd834f6960e00797f17f86";
 
   quantum = "ghcr.io/gtsteffaniak/filebrowser:stable@sha256:eb3733681db8757412632c61a99ad656f0d94ed6781bb2ea114b4d70babab78c";
+
+  phoenix = "docker.io/arizephoenix/phoenix:latest@sha256:103f5e61cf23c56a69b864f5ad2b3f307a7f55827d53fad8aeb2a07289223987";
 }

--- a/policy/web-services.nix
+++ b/policy/web-services.nix
@@ -285,6 +285,32 @@
           category = "admin";
           health.path = "/hooks/health";
         };
+
+        phoenix = {
+          subdomain = "phoenix";
+          origin = {
+            scheme = "http";
+            host = "oci-melb-1.tail0fe19b.ts.net";
+            port = 6006;
+          };
+          exposureMode = "tailscale-only";
+          declarePublic = false;
+          category = "admin";
+          health.path = "/";
+        };
+
+        bifrost = {
+          subdomain = "bifrost";
+          origin = {
+            scheme = "http";
+            host = "oci-melb-1.tail0fe19b.ts.net";
+            port = 7411;
+          };
+          exposureMode = "tailscale-only";
+          declarePublic = false;
+          category = "admin";
+          health.path = "/v1/models";
+        };
       };
     };
   };

--- a/secrets/services/postgres-shared.yaml
+++ b/secrets/services/postgres-shared.yaml
@@ -1,0 +1,30 @@
+roles:
+    audiomuse:
+        password: ENC[AES256_GCM,data:zLPHWVjd+zycLE6w60vSDArtwrPQOOg0k1mIZqdFn2euk65ypaEIpUlqpvhdhJsHBPtkZz2CDUklD/qVTHBxVQ==,iv:wQXIzgcHR2+35ifnaoh8Er4Ej2niepOfV3Zjrl7r5eY=,tag:WnLAXJ+DgMk38WE22ijGyg==,type:str]
+    litellm:
+        password: ENC[AES256_GCM,data:TQDWNrWDmKcXfQh//+ppPRNs4L380IlHSwlevAWzXdjb4/GL6ADehZ3QQk1XkiM+JytjDxP5LWbr5NkRXxwWfw==,iv:l6SWqD6sJloX8JxnLKCFL9pLpQYYEHYB8WRZU01GqKg=,tag:QRHNfDRRG+Q7fsmwa8h1Ng==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpeit0YjllMzNFL0VyY3RV
+            ekVzdFIyWDRnR2ZpZ0w1aXdWL0ZSQkRKOWpjCkpZOFY1VTVLak9LNUwzbEsrczBH
+            MWtKZ1pkeXc4QTJXdkRrcTdKOHRLQW8KLS0tIGFDSXg2N2h1aDNtdFNIVThjaTRh
+            bW1XVDMrV053WHdNdmF3bTBzUllFQncKpmCBnVgl0sKSUNf0nW2fH5y6ItV/cYV2
+            /S7Kqwtw2IqclV+jNU5lOFYWR05oPLqXJ6FBb86N/0ZBt06gf1rDEg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1w5asfm5rfncy4yvslj3az78kvn7hkrzq4vy0mzexf36w64a7e3nqamw3fp
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0L283M0xkTDN3ejFNb1Yv
+            b3oyd0k2U2lrc1I4V3pCM3p0V2VyU3BmYmdBCjJMQUhyY1c4QnZJMzZXZmFYOTV3
+            TEIvQVdPQWFveG5ZOWRlejM1NTFCWU0KLS0tIHBtUGNDZW13Z21IcjFlODhyWWwx
+            QmovTlpKZ3ZYdEZKdU9GNkEwdzY5bVEKNc5Yp0iibFcW/SEIRZLcQdMKMSSNaa4q
+            5QA8IOXb0QqWwfQlcg8p/tcBd1p9RdogF7sHr4NaxptGY0AcMhELPQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1lg45rhdn6mp856f97sdwxu7rpzyyz7edqwnldnpj67r6curnkqws7nn42a
+    lastmodified: "2026-06-20T04:50:16Z"
+    mac: ENC[AES256_GCM,data:K7wsyQMSl7kib6PAUVI3A85VAEbdmD0U55Crpo5E7JDEi4ARITgQ8CZnbnv6cnZCAYHxt6jFaYDIY2qCNuf+aD5jsHu9DcYZPb29tx9aNcG7grL4dAftqb58UnTuSG9fGT+8JZ4OObry4c6z7QKZcXXj/30nfEddkusXJ9Jci4I=,iv:HrayznxD5hSAwwfCGz600SpbGALfoeTygUYDvth3rAI=,tag:nRZEIqC9PYL10CCvrI/55A==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.1
+


### PR DESCRIPTION
This pull request introduces two major infrastructure improvements: it adds Arize Phoenix as an LLM observability platform and formalizes Postgres password management for external consumers (notably LiteLLM) using a SOPS-encrypted shared secret file. The changes include new documentation, module options, and host configuration to support these features, along with necessary firewall and backup adjustments.

**LLM Observability (Arize Phoenix):**
- Adds Arize Phoenix as an LLM observability service, including deployment on `oci-melb-1`, firewall rules, backup coverage, and comprehensive documentation on usage, architecture, and integration. [[1]](diffhunk://#diff-4954a017d14863dfe0431d74be4f50574b3d876bac9d7467697996a974e216baR29) [[2]](diffhunk://#diff-4954a017d14863dfe0431d74be4f50574b3d876bac9d7467697996a974e216baR140-R143) [[3]](diffhunk://#diff-53d05e548092bd1a39404ae1dce69d13d17302d3458a2b6655fcb5b2cec6420eR1-R142)

**Postgres Shared Secret Management for External Consumers:**
- Introduces a new SOPS-encrypted YAML file (`secrets/services/postgres-shared.yaml`) for managing Postgres role passwords for external consumers (e.g., LiteLLM, AudioMuse), with corresponding `.sops.yaml` rule and documentation. [[1]](diffhunk://#diff-a566a585e0557100ce61bf3777660a8aa5e3e56e7e89836392469bd5163663c1R87-R91) [[2]](diffhunk://#diff-f1dfef7605ceb6883466b179824cc19687cb23a938defef79ef1d9a32413c484R1-R101)
- Extends the `postgres-shared` module to support new consumers (`audiomuse`, `litellm`), options for secret file/key paths, per-role password management, CIDR-based access control, and ensures password rotation from SOPS secrets. [[1]](diffhunk://#diff-ac6c66a787f0acfd4429444f82d39b8e4fc9c71b5d15b0a8baf2aacdbf46f3a7R9-R10) [[2]](diffhunk://#diff-ac6c66a787f0acfd4429444f82d39b8e4fc9c71b5d15b0a8baf2aacdbf46f3a7R29-R78) [[3]](diffhunk://#diff-ac6c66a787f0acfd4429444f82d39b8e4fc9c71b5d15b0a8baf2aacdbf46f3a7R92-R117) [[4]](diffhunk://#diff-ac6c66a787f0acfd4429444f82d39b8e4fc9c71b5d15b0a8baf2aacdbf46f3a7R133-R202)
- Updates host configuration to enable these consumers, set the secret file path, and open the necessary firewall port for Postgres access from Podman containers. [[1]](diffhunk://#diff-4954a017d14863dfe0431d74be4f50574b3d876bac9d7467697996a974e216baR221-R224) [[2]](diffhunk://#diff-4954a017d14863dfe0431d74be4f50574b3d876bac9d7467697996a974e216baR49-R52)

**Documentation and Planning:**
- Updates the architecture and planning docs to reflect the new music service module structure and clarify the distinction between deployment-complete and E2E-validated states for services like AudioMuse. [[1]](diffhunk://#diff-61bf200863ca1adb54d7fa64bc1aafcf84547f3fd3f20db81ae2e3799b88ca77R85-R88) [[2]](diffhunk://#diff-61bf200863ca1adb54d7fa64bc1aafcf84547f3fd3f20db81ae2e3799b88ca77L129-R141)

**Spec/Metadata:**
- Adds an OpenSpec changelog entry for the Arize Phoenix observability feature.

**Summary of Most Important Changes:**

**LLM Observability**
* Added Arize Phoenix as an LLM observability service, with deployment, firewall, backup, and detailed documentation for integration and usage. [[1]](diffhunk://#diff-4954a017d14863dfe0431d74be4f50574b3d876bac9d7467697996a974e216baR29) [[2]](diffhunk://#diff-4954a017d14863dfe0431d74be4f50574b3d876bac9d7467697996a974e216baR140-R143) [[3]](diffhunk://#diff-53d05e548092bd1a39404ae1dce69d13d17302d3458a2b6655fcb5b2cec6420eR1-R142)

**Postgres Shared Secret Management**
* Introduced a SOPS-encrypted YAML file (`secrets/services/postgres-shared.yaml`) for managing external Postgres role passwords, with corresponding `.sops.yaml` rule and documentation. [[1]](diffhunk://#diff-a566a585e0557100ce61bf3777660a8aa5e3e56e7e89836392469bd5163663c1R87-R91) [[2]](diffhunk://#diff-f1dfef7605ceb6883466b179824cc19687cb23a938defef79ef1d9a32413c484R1-R101)
* Enhanced the `postgres-shared` module to support `audiomuse` and `litellm` consumers, including secret file/key options, CIDR-based access, and automated password rotation from SOPS. [[1]](diffhunk://#diff-ac6c66a787f0acfd4429444f82d39b8e4fc9c71b5d15b0a8baf2aacdbf46f3a7R9-R10) [[2]](diffhunk://#diff-ac6c66a787f0acfd4429444f82d39b8e4fc9c71b5d15b0a8baf2aacdbf46f3a7R29-R78) [[3]](diffhunk://#diff-ac6c66a787f0acfd4429444f82d39b8e4fc9c71b5d15b0a8baf2aacdbf46f3a7R92-R117) [[4]](diffhunk://#diff-ac6c66a787f0acfd4429444f82d39b8e4fc9c71b5d15b0a8baf2aacdbf46f3a7R133-R202)
* Updated host configuration to enable new consumers, set the secret file, and open the Postgres port for Podman container access. [[1]](diffhunk://#diff-4954a017d14863dfe0431d74be4f50574b3d876bac9d7467697996a974e216baR221-R224) [[2]](diffhunk://#diff-4954a017d14863dfe0431d74be4f50574b3d876bac9d7467697996a974e216baR49-R52)

**Spec/Metadata**
* Added OpenSpec changelog entry for the Arize Phoenix observability feature.